### PR TITLE
feat(issue #14 | subgraph): add AuthorizedSigner entity. add mappings

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -43,6 +43,14 @@ enum Commands {
         // #[arg(long, help = "maximum uses")]
         // max_uses: Option<u64>,
     },
+    AddAuthorizedSigner {
+        #[arg(long, help = "authorized signer")]
+        signer: Address,
+    },
+    RemoveAuthorizedSigner {
+        #[arg(long, help = "authorized signer")]
+        signer: Address,
+    },
 }
 
 abigen!(
@@ -75,7 +83,7 @@ async fn main() -> Result<()> {
 
     match opt.command {
         Commands::Active => {
-            let active_sub = subscriptions.subscription(wallet.address()).await?;
+            let active_sub = subscriptions.subscriptions(wallet.address()).await?;
             println!("{active_sub:?}");
         }
 
@@ -164,6 +172,30 @@ async fn main() -> Result<()> {
                     "nonce": format!("0x{}",hex::encode(ticket.nonce)),
                 })
             );
+        }
+        Commands::AddAuthorizedSigner { signer } => {
+            let active_sub = subscriptions.subscriptions(wallet.address()).await?;
+            println!("{active_sub:?}");
+            let call = subscriptions.add_authorized_signer(wallet.address(), signer);
+            eprintln!("add authorized signer tx: {}", call.tx.data().unwrap());
+            let receipt = client.send_transaction(call.tx, None).await?.await?;
+            let status = receipt
+                .and_then(|receipt| Some(receipt.status?.as_u64()))
+                .unwrap_or(0);
+            eprintln!("add authorized signer receipt status: {}", status);
+            ensure!(status == 1, "Failed to add the authorized signer");
+        }
+        Commands::RemoveAuthorizedSigner { signer } => {
+            let active_sub = subscriptions.subscriptions(wallet.address()).await?;
+            println!("{active_sub:?}");
+            let call = subscriptions.remove_authorized_signer(wallet.address(), signer);
+            eprintln!("remove authorized signer tx: {}", call.tx.data().unwrap());
+            let receipt = client.send_transaction(call.tx, None).await?.await?;
+            let status = receipt
+                .and_then(|receipt| Some(receipt.status?.as_u64()))
+                .unwrap_or(0);
+            eprintln!("remove authorized signer receipt status: {}", status);
+            ensure!(status == 1, "Failed to remove the authorized signer");
         }
     }
 

--- a/subgraph/abis/Subscriptions.json
+++ b/subgraph/abis/Subscriptions.json
@@ -3,17 +3,55 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "token_",
+        "name": "_token",
         "type": "address"
       },
       {
         "internalType": "uint64",
-        "name": "epochBlocks_",
+        "name": "_epochSeconds",
         "type": "uint64"
       }
     ],
     "stateMutability": "nonpayable",
     "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "subscriptionOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "authorizedSigner",
+        "type": "address"
+      }
+    ],
+    "name": "AuthorizedSignerAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "subscriptionOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "authorizedSigner",
+        "type": "address"
+      }
+    ],
+    "name": "AuthorizedSignerRemoved",
+    "type": "event"
   },
   {
     "anonymous": false,
@@ -45,6 +83,25 @@
       }
     ],
     "name": "Init",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
     "type": "event"
   },
   {
@@ -92,6 +149,85 @@
     "type": "event"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_signer",
+        "type": "address"
+      }
+    ],
+    "name": "addAuthorizedSigner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "authorizedSigners",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_signer",
+        "type": "address"
+      }
+    ],
+    "name": "checkAuthorizedSigner",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_offset",
+        "type": "uint256"
+      }
+    ],
+    "name": "collect",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "collect",
     "outputs": [],
@@ -100,12 +236,62 @@
   },
   {
     "inputs": [],
-    "name": "epochBlocks",
+    "name": "collectPerEpoch",
+    "outputs": [
+      {
+        "internalType": "int128",
+        "name": "",
+        "type": "int128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "currentEpoch",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "epochSeconds",
     "outputs": [
       {
         "internalType": "uint64",
         "name": "",
         "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "epochs",
+    "outputs": [
+      {
+        "internalType": "int128",
+        "name": "delta",
+        "type": "int128"
+      },
+      {
+        "internalType": "int128",
+        "name": "extra",
+        "type": "int128"
       }
     ],
     "stateMutability": "view",
@@ -124,9 +310,75 @@
         "type": "uint64"
       }
     ],
-    "name": "extend",
+    "name": "extendSubscription",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "fulfil",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "_subStart",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "_subEnd",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint128",
+        "name": "_subRate",
+        "type": "uint128"
+      }
+    ],
+    "name": "locked",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      }
+    ],
+    "name": "locked",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -140,6 +392,59 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_signer",
+        "type": "address"
+      }
+    ],
+    "name": "removeAuthorizedSigner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint64",
+        "name": "start",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "end",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint128",
+        "name": "rate",
+        "type": "uint128"
+      }
+    ],
+    "name": "setPendingSubscription",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -174,33 +479,45 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "user",
+        "name": "",
         "type": "address"
       }
     ],
-    "name": "subscription",
+    "name": "subscriptions",
     "outputs": [
       {
-        "components": [
-          {
-            "internalType": "uint64",
-            "name": "start",
-            "type": "uint64"
-          },
-          {
-            "internalType": "uint64",
-            "name": "end",
-            "type": "uint64"
-          },
-          {
-            "internalType": "uint128",
-            "name": "rate",
-            "type": "uint128"
-          }
-        ],
-        "internalType": "struct Subscriptions.Subscription",
+        "internalType": "uint64",
+        "name": "start",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "end",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint128",
+        "name": "rate",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "timestampToEpoch",
+    "outputs": [
+      {
+        "internalType": "uint256",
         "name": "",
-        "type": "tuple"
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -214,6 +531,80 @@
         "internalType": "contract IERC20",
         "name": "",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "uncollectedEpoch",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "_subStart",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "_subEnd",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint128",
+        "name": "_subRate",
+        "type": "uint128"
+      }
+    ],
+    "name": "unlocked",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      }
+    ],
+    "name": "unlocked",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
       }
     ],
     "stateMutability": "view",

--- a/subgraph/generated/Subscriptions/Subscriptions.ts
+++ b/subgraph/generated/Subscriptions/Subscriptions.ts
@@ -10,6 +10,50 @@ import {
   BigInt
 } from "@graphprotocol/graph-ts";
 
+export class AuthorizedSignerAdded extends ethereum.Event {
+  get params(): AuthorizedSignerAdded__Params {
+    return new AuthorizedSignerAdded__Params(this);
+  }
+}
+
+export class AuthorizedSignerAdded__Params {
+  _event: AuthorizedSignerAdded;
+
+  constructor(event: AuthorizedSignerAdded) {
+    this._event = event;
+  }
+
+  get subscriptionOwner(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get authorizedSigner(): Address {
+    return this._event.parameters[1].value.toAddress();
+  }
+}
+
+export class AuthorizedSignerRemoved extends ethereum.Event {
+  get params(): AuthorizedSignerRemoved__Params {
+    return new AuthorizedSignerRemoved__Params(this);
+  }
+}
+
+export class AuthorizedSignerRemoved__Params {
+  _event: AuthorizedSignerRemoved;
+
+  constructor(event: AuthorizedSignerRemoved) {
+    this._event = event;
+  }
+
+  get subscriptionOwner(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get authorizedSigner(): Address {
+    return this._event.parameters[1].value.toAddress();
+  }
+}
+
 export class Extend extends ethereum.Event {
   get params(): Extend__Params {
     return new Extend__Params(this);
@@ -47,6 +91,28 @@ export class Init__Params {
 
   get token(): Address {
     return this._event.parameters[0].value.toAddress();
+  }
+}
+
+export class OwnershipTransferred extends ethereum.Event {
+  get params(): OwnershipTransferred__Params {
+    return new OwnershipTransferred__Params(this);
+  }
+}
+
+export class OwnershipTransferred__Params {
+  _event: OwnershipTransferred;
+
+  constructor(event: OwnershipTransferred) {
+    this._event = event;
+  }
+
+  get previousOwner(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get newOwner(): Address {
+    return this._event.parameters[1].value.toAddress();
   }
 }
 
@@ -98,17 +164,60 @@ export class Unsubscribe__Params {
   }
 }
 
-export class Subscriptions__subscriptionResultValue0Struct extends ethereum.Tuple {
-  get start(): BigInt {
-    return this[0].toBigInt();
+export class Subscriptions__epochsResult {
+  value0: BigInt;
+  value1: BigInt;
+
+  constructor(value0: BigInt, value1: BigInt) {
+    this.value0 = value0;
+    this.value1 = value1;
   }
 
-  get end(): BigInt {
-    return this[1].toBigInt();
+  toMap(): TypedMap<string, ethereum.Value> {
+    let map = new TypedMap<string, ethereum.Value>();
+    map.set("value0", ethereum.Value.fromSignedBigInt(this.value0));
+    map.set("value1", ethereum.Value.fromSignedBigInt(this.value1));
+    return map;
   }
 
-  get rate(): BigInt {
-    return this[2].toBigInt();
+  getDelta(): BigInt {
+    return this.value0;
+  }
+
+  getExtra(): BigInt {
+    return this.value1;
+  }
+}
+
+export class Subscriptions__subscriptionsResult {
+  value0: BigInt;
+  value1: BigInt;
+  value2: BigInt;
+
+  constructor(value0: BigInt, value1: BigInt, value2: BigInt) {
+    this.value0 = value0;
+    this.value1 = value1;
+    this.value2 = value2;
+  }
+
+  toMap(): TypedMap<string, ethereum.Value> {
+    let map = new TypedMap<string, ethereum.Value>();
+    map.set("value0", ethereum.Value.fromUnsignedBigInt(this.value0));
+    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1));
+    map.set("value2", ethereum.Value.fromUnsignedBigInt(this.value2));
+    return map;
+  }
+
+  getStart(): BigInt {
+    return this.value0;
+  }
+
+  getEnd(): BigInt {
+    return this.value1;
+  }
+
+  getRate(): BigInt {
+    return this.value2;
   }
 }
 
@@ -117,14 +226,182 @@ export class Subscriptions extends ethereum.SmartContract {
     return new Subscriptions("Subscriptions", address);
   }
 
-  epochBlocks(): BigInt {
-    let result = super.call("epochBlocks", "epochBlocks():(uint64)", []);
+  authorizedSigners(param0: Address, param1: Address): boolean {
+    let result = super.call(
+      "authorizedSigners",
+      "authorizedSigners(address,address):(bool)",
+      [ethereum.Value.fromAddress(param0), ethereum.Value.fromAddress(param1)]
+    );
+
+    return result[0].toBoolean();
+  }
+
+  try_authorizedSigners(
+    param0: Address,
+    param1: Address
+  ): ethereum.CallResult<boolean> {
+    let result = super.tryCall(
+      "authorizedSigners",
+      "authorizedSigners(address,address):(bool)",
+      [ethereum.Value.fromAddress(param0), ethereum.Value.fromAddress(param1)]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
+  }
+
+  checkAuthorizedSigner(_user: Address, _signer: Address): boolean {
+    let result = super.call(
+      "checkAuthorizedSigner",
+      "checkAuthorizedSigner(address,address):(bool)",
+      [ethereum.Value.fromAddress(_user), ethereum.Value.fromAddress(_signer)]
+    );
+
+    return result[0].toBoolean();
+  }
+
+  try_checkAuthorizedSigner(
+    _user: Address,
+    _signer: Address
+  ): ethereum.CallResult<boolean> {
+    let result = super.tryCall(
+      "checkAuthorizedSigner",
+      "checkAuthorizedSigner(address,address):(bool)",
+      [ethereum.Value.fromAddress(_user), ethereum.Value.fromAddress(_signer)]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
+  }
+
+  collectPerEpoch(): BigInt {
+    let result = super.call(
+      "collectPerEpoch",
+      "collectPerEpoch():(int128)",
+      []
+    );
 
     return result[0].toBigInt();
   }
 
-  try_epochBlocks(): ethereum.CallResult<BigInt> {
-    let result = super.tryCall("epochBlocks", "epochBlocks():(uint64)", []);
+  try_collectPerEpoch(): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "collectPerEpoch",
+      "collectPerEpoch():(int128)",
+      []
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  currentEpoch(): BigInt {
+    let result = super.call("currentEpoch", "currentEpoch():(uint256)", []);
+
+    return result[0].toBigInt();
+  }
+
+  try_currentEpoch(): ethereum.CallResult<BigInt> {
+    let result = super.tryCall("currentEpoch", "currentEpoch():(uint256)", []);
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  epochSeconds(): BigInt {
+    let result = super.call("epochSeconds", "epochSeconds():(uint64)", []);
+
+    return result[0].toBigInt();
+  }
+
+  try_epochSeconds(): ethereum.CallResult<BigInt> {
+    let result = super.tryCall("epochSeconds", "epochSeconds():(uint64)", []);
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  epochs(param0: BigInt): Subscriptions__epochsResult {
+    let result = super.call("epochs", "epochs(uint256):(int128,int128)", [
+      ethereum.Value.fromUnsignedBigInt(param0)
+    ]);
+
+    return new Subscriptions__epochsResult(
+      result[0].toBigInt(),
+      result[1].toBigInt()
+    );
+  }
+
+  try_epochs(param0: BigInt): ethereum.CallResult<Subscriptions__epochsResult> {
+    let result = super.tryCall("epochs", "epochs(uint256):(int128,int128)", [
+      ethereum.Value.fromUnsignedBigInt(param0)
+    ]);
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(
+      new Subscriptions__epochsResult(value[0].toBigInt(), value[1].toBigInt())
+    );
+  }
+
+  locked(_subStart: BigInt, _subEnd: BigInt, _subRate: BigInt): BigInt {
+    let result = super.call(
+      "locked",
+      "locked(uint64,uint64,uint128):(uint128)",
+      [
+        ethereum.Value.fromUnsignedBigInt(_subStart),
+        ethereum.Value.fromUnsignedBigInt(_subEnd),
+        ethereum.Value.fromUnsignedBigInt(_subRate)
+      ]
+    );
+
+    return result[0].toBigInt();
+  }
+
+  try_locked(
+    _subStart: BigInt,
+    _subEnd: BigInt,
+    _subRate: BigInt
+  ): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "locked",
+      "locked(uint64,uint64,uint128):(uint128)",
+      [
+        ethereum.Value.fromUnsignedBigInt(_subStart),
+        ethereum.Value.fromUnsignedBigInt(_subEnd),
+        ethereum.Value.fromUnsignedBigInt(_subRate)
+      ]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  locked1(_user: Address): BigInt {
+    let result = super.call("locked", "locked(address):(uint128)", [
+      ethereum.Value.fromAddress(_user)
+    ]);
+
+    return result[0].toBigInt();
+  }
+
+  try_locked1(_user: Address): ethereum.CallResult<BigInt> {
+    let result = super.tryCall("locked", "locked(address):(uint128)", [
+      ethereum.Value.fromAddress(_user)
+    ]);
     if (result.reverted) {
       return new ethereum.CallResult();
     }
@@ -147,35 +424,62 @@ export class Subscriptions extends ethereum.SmartContract {
     return ethereum.CallResult.fromValue(value[0].toAddress());
   }
 
-  subscription(user: Address): Subscriptions__subscriptionResultValue0Struct {
+  subscriptions(param0: Address): Subscriptions__subscriptionsResult {
     let result = super.call(
-      "subscription",
-      "subscription(address):((uint64,uint64,uint128))",
-      [ethereum.Value.fromAddress(user)]
+      "subscriptions",
+      "subscriptions(address):(uint64,uint64,uint128)",
+      [ethereum.Value.fromAddress(param0)]
     );
 
-    return changetype<Subscriptions__subscriptionResultValue0Struct>(
-      result[0].toTuple()
+    return new Subscriptions__subscriptionsResult(
+      result[0].toBigInt(),
+      result[1].toBigInt(),
+      result[2].toBigInt()
     );
   }
 
-  try_subscription(
-    user: Address
-  ): ethereum.CallResult<Subscriptions__subscriptionResultValue0Struct> {
+  try_subscriptions(
+    param0: Address
+  ): ethereum.CallResult<Subscriptions__subscriptionsResult> {
     let result = super.tryCall(
-      "subscription",
-      "subscription(address):((uint64,uint64,uint128))",
-      [ethereum.Value.fromAddress(user)]
+      "subscriptions",
+      "subscriptions(address):(uint64,uint64,uint128)",
+      [ethereum.Value.fromAddress(param0)]
     );
     if (result.reverted) {
       return new ethereum.CallResult();
     }
     let value = result.value;
     return ethereum.CallResult.fromValue(
-      changetype<Subscriptions__subscriptionResultValue0Struct>(
-        value[0].toTuple()
+      new Subscriptions__subscriptionsResult(
+        value[0].toBigInt(),
+        value[1].toBigInt(),
+        value[2].toBigInt()
       )
     );
+  }
+
+  timestampToEpoch(_timestamp: BigInt): BigInt {
+    let result = super.call(
+      "timestampToEpoch",
+      "timestampToEpoch(uint256):(uint256)",
+      [ethereum.Value.fromUnsignedBigInt(_timestamp)]
+    );
+
+    return result[0].toBigInt();
+  }
+
+  try_timestampToEpoch(_timestamp: BigInt): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "timestampToEpoch",
+      "timestampToEpoch(uint256):(uint256)",
+      [ethereum.Value.fromUnsignedBigInt(_timestamp)]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   token(): Address {
@@ -191,6 +495,83 @@ export class Subscriptions extends ethereum.SmartContract {
     }
     let value = result.value;
     return ethereum.CallResult.fromValue(value[0].toAddress());
+  }
+
+  uncollectedEpoch(): BigInt {
+    let result = super.call(
+      "uncollectedEpoch",
+      "uncollectedEpoch():(uint256)",
+      []
+    );
+
+    return result[0].toBigInt();
+  }
+
+  try_uncollectedEpoch(): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "uncollectedEpoch",
+      "uncollectedEpoch():(uint256)",
+      []
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  unlocked(_subStart: BigInt, _subEnd: BigInt, _subRate: BigInt): BigInt {
+    let result = super.call(
+      "unlocked",
+      "unlocked(uint64,uint64,uint128):(uint128)",
+      [
+        ethereum.Value.fromUnsignedBigInt(_subStart),
+        ethereum.Value.fromUnsignedBigInt(_subEnd),
+        ethereum.Value.fromUnsignedBigInt(_subRate)
+      ]
+    );
+
+    return result[0].toBigInt();
+  }
+
+  try_unlocked(
+    _subStart: BigInt,
+    _subEnd: BigInt,
+    _subRate: BigInt
+  ): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "unlocked",
+      "unlocked(uint64,uint64,uint128):(uint128)",
+      [
+        ethereum.Value.fromUnsignedBigInt(_subStart),
+        ethereum.Value.fromUnsignedBigInt(_subEnd),
+        ethereum.Value.fromUnsignedBigInt(_subRate)
+      ]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  unlocked1(_user: Address): BigInt {
+    let result = super.call("unlocked", "unlocked(address):(uint128)", [
+      ethereum.Value.fromAddress(_user)
+    ]);
+
+    return result[0].toBigInt();
+  }
+
+  try_unlocked1(_user: Address): ethereum.CallResult<BigInt> {
+    let result = super.tryCall("unlocked", "unlocked(address):(uint128)", [
+      ethereum.Value.fromAddress(_user)
+    ]);
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 }
 
@@ -211,11 +592,11 @@ export class ConstructorCall__Inputs {
     this._call = call;
   }
 
-  get token_(): Address {
+  get _token(): Address {
     return this._call.inputValues[0].value.toAddress();
   }
 
-  get epochBlocks_(): BigInt {
+  get _epochSeconds(): BigInt {
     return this._call.inputValues[1].value.toBigInt();
   }
 }
@@ -224,6 +605,40 @@ export class ConstructorCall__Outputs {
   _call: ConstructorCall;
 
   constructor(call: ConstructorCall) {
+    this._call = call;
+  }
+}
+
+export class AddAuthorizedSignerCall extends ethereum.Call {
+  get inputs(): AddAuthorizedSignerCall__Inputs {
+    return new AddAuthorizedSignerCall__Inputs(this);
+  }
+
+  get outputs(): AddAuthorizedSignerCall__Outputs {
+    return new AddAuthorizedSignerCall__Outputs(this);
+  }
+}
+
+export class AddAuthorizedSignerCall__Inputs {
+  _call: AddAuthorizedSignerCall;
+
+  constructor(call: AddAuthorizedSignerCall) {
+    this._call = call;
+  }
+
+  get _user(): Address {
+    return this._call.inputValues[0].value.toAddress();
+  }
+
+  get _signer(): Address {
+    return this._call.inputValues[1].value.toAddress();
+  }
+}
+
+export class AddAuthorizedSignerCall__Outputs {
+  _call: AddAuthorizedSignerCall;
+
+  constructor(call: AddAuthorizedSignerCall) {
     this._call = call;
   }
 }
@@ -244,6 +659,10 @@ export class CollectCall__Inputs {
   constructor(call: CollectCall) {
     this._call = call;
   }
+
+  get _offset(): BigInt {
+    return this._call.inputValues[0].value.toBigInt();
+  }
 }
 
 export class CollectCall__Outputs {
@@ -254,20 +673,46 @@ export class CollectCall__Outputs {
   }
 }
 
-export class ExtendCall extends ethereum.Call {
-  get inputs(): ExtendCall__Inputs {
-    return new ExtendCall__Inputs(this);
+export class Collect1Call extends ethereum.Call {
+  get inputs(): Collect1Call__Inputs {
+    return new Collect1Call__Inputs(this);
   }
 
-  get outputs(): ExtendCall__Outputs {
-    return new ExtendCall__Outputs(this);
+  get outputs(): Collect1Call__Outputs {
+    return new Collect1Call__Outputs(this);
   }
 }
 
-export class ExtendCall__Inputs {
-  _call: ExtendCall;
+export class Collect1Call__Inputs {
+  _call: Collect1Call;
 
-  constructor(call: ExtendCall) {
+  constructor(call: Collect1Call) {
+    this._call = call;
+  }
+}
+
+export class Collect1Call__Outputs {
+  _call: Collect1Call;
+
+  constructor(call: Collect1Call) {
+    this._call = call;
+  }
+}
+
+export class ExtendSubscriptionCall extends ethereum.Call {
+  get inputs(): ExtendSubscriptionCall__Inputs {
+    return new ExtendSubscriptionCall__Inputs(this);
+  }
+
+  get outputs(): ExtendSubscriptionCall__Outputs {
+    return new ExtendSubscriptionCall__Outputs(this);
+  }
+}
+
+export class ExtendSubscriptionCall__Inputs {
+  _call: ExtendSubscriptionCall;
+
+  constructor(call: ExtendSubscriptionCall) {
     this._call = call;
   }
 
@@ -280,10 +725,146 @@ export class ExtendCall__Inputs {
   }
 }
 
-export class ExtendCall__Outputs {
-  _call: ExtendCall;
+export class ExtendSubscriptionCall__Outputs {
+  _call: ExtendSubscriptionCall;
 
-  constructor(call: ExtendCall) {
+  constructor(call: ExtendSubscriptionCall) {
+    this._call = call;
+  }
+}
+
+export class FulfilCall extends ethereum.Call {
+  get inputs(): FulfilCall__Inputs {
+    return new FulfilCall__Inputs(this);
+  }
+
+  get outputs(): FulfilCall__Outputs {
+    return new FulfilCall__Outputs(this);
+  }
+}
+
+export class FulfilCall__Inputs {
+  _call: FulfilCall;
+
+  constructor(call: FulfilCall) {
+    this._call = call;
+  }
+
+  get _to(): Address {
+    return this._call.inputValues[0].value.toAddress();
+  }
+
+  get value1(): BigInt {
+    return this._call.inputValues[1].value.toBigInt();
+  }
+}
+
+export class FulfilCall__Outputs {
+  _call: FulfilCall;
+
+  constructor(call: FulfilCall) {
+    this._call = call;
+  }
+}
+
+export class RemoveAuthorizedSignerCall extends ethereum.Call {
+  get inputs(): RemoveAuthorizedSignerCall__Inputs {
+    return new RemoveAuthorizedSignerCall__Inputs(this);
+  }
+
+  get outputs(): RemoveAuthorizedSignerCall__Outputs {
+    return new RemoveAuthorizedSignerCall__Outputs(this);
+  }
+}
+
+export class RemoveAuthorizedSignerCall__Inputs {
+  _call: RemoveAuthorizedSignerCall;
+
+  constructor(call: RemoveAuthorizedSignerCall) {
+    this._call = call;
+  }
+
+  get _user(): Address {
+    return this._call.inputValues[0].value.toAddress();
+  }
+
+  get _signer(): Address {
+    return this._call.inputValues[1].value.toAddress();
+  }
+}
+
+export class RemoveAuthorizedSignerCall__Outputs {
+  _call: RemoveAuthorizedSignerCall;
+
+  constructor(call: RemoveAuthorizedSignerCall) {
+    this._call = call;
+  }
+}
+
+export class RenounceOwnershipCall extends ethereum.Call {
+  get inputs(): RenounceOwnershipCall__Inputs {
+    return new RenounceOwnershipCall__Inputs(this);
+  }
+
+  get outputs(): RenounceOwnershipCall__Outputs {
+    return new RenounceOwnershipCall__Outputs(this);
+  }
+}
+
+export class RenounceOwnershipCall__Inputs {
+  _call: RenounceOwnershipCall;
+
+  constructor(call: RenounceOwnershipCall) {
+    this._call = call;
+  }
+}
+
+export class RenounceOwnershipCall__Outputs {
+  _call: RenounceOwnershipCall;
+
+  constructor(call: RenounceOwnershipCall) {
+    this._call = call;
+  }
+}
+
+export class SetPendingSubscriptionCall extends ethereum.Call {
+  get inputs(): SetPendingSubscriptionCall__Inputs {
+    return new SetPendingSubscriptionCall__Inputs(this);
+  }
+
+  get outputs(): SetPendingSubscriptionCall__Outputs {
+    return new SetPendingSubscriptionCall__Outputs(this);
+  }
+}
+
+export class SetPendingSubscriptionCall__Inputs {
+  _call: SetPendingSubscriptionCall;
+
+  constructor(call: SetPendingSubscriptionCall) {
+    this._call = call;
+  }
+
+  get user(): Address {
+    return this._call.inputValues[0].value.toAddress();
+  }
+
+  get start(): BigInt {
+    return this._call.inputValues[1].value.toBigInt();
+  }
+
+  get end(): BigInt {
+    return this._call.inputValues[2].value.toBigInt();
+  }
+
+  get rate(): BigInt {
+    return this._call.inputValues[3].value.toBigInt();
+  }
+}
+
+export class SetPendingSubscriptionCall__Outputs {
+  _call: SetPendingSubscriptionCall;
+
+  constructor(call: SetPendingSubscriptionCall) {
     this._call = call;
   }
 }
@@ -326,6 +907,36 @@ export class SubscribeCall__Outputs {
   _call: SubscribeCall;
 
   constructor(call: SubscribeCall) {
+    this._call = call;
+  }
+}
+
+export class TransferOwnershipCall extends ethereum.Call {
+  get inputs(): TransferOwnershipCall__Inputs {
+    return new TransferOwnershipCall__Inputs(this);
+  }
+
+  get outputs(): TransferOwnershipCall__Outputs {
+    return new TransferOwnershipCall__Outputs(this);
+  }
+}
+
+export class TransferOwnershipCall__Inputs {
+  _call: TransferOwnershipCall;
+
+  constructor(call: TransferOwnershipCall) {
+    this._call = call;
+  }
+
+  get newOwner(): Address {
+    return this._call.inputValues[0].value.toAddress();
+  }
+}
+
+export class TransferOwnershipCall__Outputs {
+  _call: TransferOwnershipCall;
+
+  constructor(call: TransferOwnershipCall) {
     this._call = call;
   }
 }

--- a/subgraph/generated/schema.ts
+++ b/subgraph/generated/schema.ts
@@ -391,4 +391,82 @@ export class ActiveSubscription extends Entity {
   set rate(value: BigInt) {
     this.set("rate", Value.fromBigInt(value));
   }
+
+  get authorizedSigners(): Array<Bytes> | null {
+    let value = this.get("authorizedSigners");
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBytesArray();
+    }
+  }
+
+  set authorizedSigners(value: Array<Bytes> | null) {
+    if (!value) {
+      this.unset("authorizedSigners");
+    } else {
+      this.set("authorizedSigners", Value.fromBytesArray(<Array<Bytes>>value));
+    }
+  }
+}
+
+export class AuthorizedSigner extends Entity {
+  constructor(id: Bytes) {
+    super();
+    this.set("id", Value.fromBytes(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(id != null, "Cannot save AuthorizedSigner entity without an ID");
+    if (id) {
+      assert(
+        id.kind == ValueKind.BYTES,
+        `Entities of type AuthorizedSigner must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`
+      );
+      store.set("AuthorizedSigner", id.toBytes().toHexString(), this);
+    }
+  }
+
+  static load(id: Bytes): AuthorizedSigner | null {
+    return changetype<AuthorizedSigner | null>(
+      store.get("AuthorizedSigner", id.toHexString())
+    );
+  }
+
+  get id(): Bytes {
+    let value = this.get("id");
+    return value!.toBytes();
+  }
+
+  set id(value: Bytes) {
+    this.set("id", Value.fromBytes(value));
+  }
+
+  get user(): Bytes {
+    let value = this.get("user");
+    return value!.toBytes();
+  }
+
+  set user(value: Bytes) {
+    this.set("user", Value.fromBytes(value));
+  }
+
+  get signer(): Bytes {
+    let value = this.get("signer");
+    return value!.toBytes();
+  }
+
+  set signer(value: Bytes) {
+    this.set("signer", Value.fromBytes(value));
+  }
+
+  get activeSubscription(): Bytes {
+    let value = this.get("activeSubscription");
+    return value!.toBytes();
+  }
+
+  set activeSubscription(value: Bytes) {
+    this.set("activeSubscription", Value.fromBytes(value));
+  }
 }

--- a/subgraph/generated/schema.ts
+++ b/subgraph/generated/schema.ts
@@ -461,12 +461,20 @@ export class AuthorizedSigner extends Entity {
     this.set("signer", Value.fromBytes(value));
   }
 
-  get activeSubscription(): Bytes {
+  get activeSubscription(): Bytes | null {
     let value = this.get("activeSubscription");
-    return value!.toBytes();
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBytes();
+    }
   }
 
-  set activeSubscription(value: Bytes) {
-    this.set("activeSubscription", Value.fromBytes(value));
+  set activeSubscription(value: Bytes | null) {
+    if (!value) {
+      this.unset("activeSubscription");
+    } else {
+      this.set("activeSubscription", Value.fromBytes(<Bytes>value));
+    }
   }
 }

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -40,4 +40,13 @@ type ActiveSubscription @entity {
   start: BigInt! # uint64
   end: BigInt! # uint64
   rate: BigInt! # uint128
+  authorizedSigners: [AuthorizedSigner!]
+    @derivedFrom(field: "activeSubscription")
+}
+
+type AuthorizedSigner @entity(immutable: true) {
+  id: Bytes! #keccak256 hex string of user:signer
+  user: Bytes! #address
+  signer: Bytes! #address
+  activeSubscription: ActiveSubscription!
 }

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -44,9 +44,9 @@ type ActiveSubscription @entity {
     @derivedFrom(field: "activeSubscription")
 }
 
-type AuthorizedSigner @entity(immutable: true) {
+type AuthorizedSigner @entity {
   id: Bytes! #keccak256 hex string of user:signer
   user: Bytes! #address
   signer: Bytes! #address
-  activeSubscription: ActiveSubscription!
+  activeSubscription: ActiveSubscription
 }

--- a/subgraph/src/utils.ts
+++ b/subgraph/src/utils.ts
@@ -10,8 +10,8 @@ export function buildAuthorizedSignerId(
   subscriptionOwner: Address,
   authorizedSigner: Address
 ): Bytes {
-  let hex = crypto
-    .keccak256(ByteArray.fromUTF8(`${subscriptionOwner}:${authorizedSigner}`))
-    .toHexString();
-  return Bytes.fromHexString(hex);
+  let hash = crypto.keccak256(
+    ByteArray.fromUTF8(`${subscriptionOwner}:${authorizedSigner}`)
+  );
+  return Bytes.fromByteArray(hash);
 }

--- a/subgraph/src/utils.ts
+++ b/subgraph/src/utils.ts
@@ -1,0 +1,17 @@
+import {Address, ByteArray, Bytes, crypto} from '@graphprotocol/graph-ts';
+
+/**
+ * Generate a keccak256 hex string of the user:authorizedSigner
+ * @param subscriptionOwner address of the ActiveSubscription owner
+ * @param authorizedSigner address of the user authorized to sign for the owner of the ActiveSubscription
+ * @returns Bytes representation of a hex string concatenation of the `user:authorizedSigner` to create a unique id
+ */
+export function buildAuthorizedSignerId(
+  subscriptionOwner: Address,
+  authorizedSigner: Address
+): Bytes {
+  let hex = crypto
+    .keccak256(ByteArray.fromUTF8(`${subscriptionOwner}:${authorizedSigner}`))
+    .toHexString();
+  return Bytes.fromHexString(hex);
+}

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -16,6 +16,8 @@ dataSources:
         - Init
         - Subscribe
         - Unsubscribe
+        - Extend
+        - ActiveSubscription
       abis:
         - name: Subscriptions
           file: ./abis/Subscriptions.json
@@ -26,4 +28,8 @@ dataSources:
           handler: handleSubscribe
         - event: Unsubscribe(indexed address)
           handler: handleUnsubscribe
+        - event: AuthorizedSignerAdded(indexed address,indexed address)
+          handler: handleAuthorizedSignerAdded
+        - event: AuthorizedSignerRemoved(indexed address,indexed address)
+          handler: handleAuthorizedSignerRemoved
       file: ./src/subscriptions.ts

--- a/subgraph/tests/subscriptions-utils.ts
+++ b/subgraph/tests/subscriptions-utils.ts
@@ -1,6 +1,8 @@
 import {newMockEvent} from 'matchstick-as';
 import {ethereum, Address, BigInt} from '@graphprotocol/graph-ts';
 import {
+  AuthorizedSignerAdded,
+  AuthorizedSignerRemoved,
   Extend,
   Subscribe,
   Unsubscribe,
@@ -81,4 +83,56 @@ export function createExtendEvent(
   );
 
   return extendEvent;
+}
+
+export function createAuthorizedSignerAddedEvent(
+  subscriptionOwner: Address,
+  authorizedSigner: Address
+): AuthorizedSignerAdded {
+  let authorizedSignerAddedEvent = changetype<AuthorizedSignerAdded>(
+    newMockEvent()
+  );
+
+  authorizedSignerAddedEvent.parameters = new Array();
+
+  authorizedSignerAddedEvent.parameters.push(
+    new ethereum.EventParam(
+      'subscriptionOwner',
+      ethereum.Value.fromAddress(subscriptionOwner)
+    )
+  );
+  authorizedSignerAddedEvent.parameters.push(
+    new ethereum.EventParam(
+      'authorizedSigner',
+      ethereum.Value.fromAddress(authorizedSigner)
+    )
+  );
+
+  return authorizedSignerAddedEvent;
+}
+
+export function createAuthorizedSignerRemovedEvent(
+  subscriptionOwner: Address,
+  authorizedSigner: Address
+): AuthorizedSignerRemoved {
+  let authorizedSignerRemovedEvent = changetype<AuthorizedSignerRemoved>(
+    newMockEvent()
+  );
+
+  authorizedSignerRemovedEvent.parameters = new Array();
+
+  authorizedSignerRemovedEvent.parameters.push(
+    new ethereum.EventParam(
+      'subscriptionOwner',
+      ethereum.Value.fromAddress(subscriptionOwner)
+    )
+  );
+  authorizedSignerRemovedEvent.parameters.push(
+    new ethereum.EventParam(
+      'authorizedSigner',
+      ethereum.Value.fromAddress(authorizedSigner)
+    )
+  );
+
+  return authorizedSignerRemovedEvent;
 }

--- a/subgraph/tests/subscriptions.test.ts
+++ b/subgraph/tests/subscriptions.test.ts
@@ -223,4 +223,92 @@ describe('Describe entity assertions', () => {
       authorizedSignerEntity1Id.toHexString()
     );
   });
+
+  test('should unlink AuthorizedSigners from an ActiveSubscription on unsubscribe', () => {
+    // create the active subscription
+    const validateAuthSignerTestUser =
+      '0x0000000000000000000000000000000000000004';
+    let activateSubscriptionEvent = createSubscribeEvent(
+      Address.fromString(validateAuthSignerTestUser),
+      BigInt.fromU32(2000),
+      BigInt.fromU32(5000),
+      BigInt.fromU32(10)
+        .pow(18)
+        .times(BigInt.fromU32(2))
+    );
+    activateSubscriptionEvent.logIndex = BigInt.fromU32(8);
+
+    handleSubscribe(activateSubscriptionEvent);
+
+    assert.fieldEquals(
+      'ActiveSubscription',
+      validateAuthSignerTestUser,
+      'user',
+      validateAuthSignerTestUser
+    );
+    assert.fieldEquals(
+      'ActiveSubscription',
+      validateAuthSignerTestUser,
+      'start',
+      '2000'
+    );
+    assert.fieldEquals(
+      'ActiveSubscription',
+      validateAuthSignerTestUser,
+      'end',
+      '5000'
+    );
+    assert.fieldEquals(
+      'ActiveSubscription',
+      validateAuthSignerTestUser,
+      'rate',
+      '2000000000000000000'
+    );
+
+    // add AuthorizedSigner
+    const signer = '0x0000000000000000000000000000000000000005';
+    let subscriptionOwner = Address.fromString(validateAuthSignerTestUser);
+    let authorizedSigner = Address.fromString(signer);
+    let addAuthorizedSignerEvent = createAuthorizedSignerAddedEvent(
+      subscriptionOwner,
+      authorizedSigner
+    );
+    addAuthorizedSignerEvent.logIndex = BigInt.fromU32(9);
+
+    handleAuthorizedSignerAdded(addAuthorizedSignerEvent);
+
+    let authorizedSignerEntityId = buildAuthorizedSignerId(
+      subscriptionOwner,
+      authorizedSigner
+    );
+    assert.fieldEquals(
+      'AuthorizedSigner',
+      authorizedSignerEntityId.toHexString(),
+      'user',
+      validateAuthSignerTestUser
+    );
+    assert.fieldEquals(
+      'AuthorizedSigner',
+      authorizedSignerEntityId.toHexString(),
+      'signer',
+      authorizedSigner.toHexString()
+    );
+    assert.fieldEquals(
+      'AuthorizedSigner',
+      authorizedSignerEntityId.toHexString(),
+      'activeSubscription',
+      validateAuthSignerTestUser
+    );
+
+    // call unsubscribe
+    let unsubscribeEvent = createUnsubscribeEvent(
+      Address.fromString(validateAuthSignerTestUser)
+    );
+    unsubscribeEvent.logIndex = BigInt.fromU32(10);
+
+    handleUnsubscribe(unsubscribeEvent);
+
+    // and that the ActiveSubscription has been removed
+    assert.notInStore('ActiveSubscription', validateAuthSignerTestUser);
+  });
 });

--- a/subgraph/tests/subscriptions.test.ts
+++ b/subgraph/tests/subscriptions.test.ts
@@ -6,13 +6,20 @@ import {
   beforeAll,
   afterAll,
 } from 'matchstick-as/assembly/index';
+
 import {Address, BigInt} from '@graphprotocol/graph-ts';
+
 import {
   handleExtend,
   handleSubscribe,
   handleUnsubscribe,
+  handleAuthorizedSignerAdded,
+  handleAuthorizedSignerRemoved,
 } from '../src/subscriptions';
+import {buildAuthorizedSignerId} from '../src/utils';
 import {
+  createAuthorizedSignerAddedEvent,
+  createAuthorizedSignerRemovedEvent,
   createExtendEvent,
   createSubscribeEvent,
   createUnsubscribeEvent,
@@ -119,6 +126,101 @@ describe('Describe entity assertions', () => {
       user,
       'rate',
       '3000000000000000000'
+    );
+  });
+
+  test('should be able to add an AuthorizedSigner entity for the ActiveSubscription. but must be unique', () => {
+    const signer = '0x0000000000000000000000000000000000000002';
+    let subscriptionOwner = Address.fromString(user);
+    let authorizedSigner = Address.fromString(signer);
+    let event1 = createAuthorizedSignerAddedEvent(
+      subscriptionOwner,
+      authorizedSigner
+    );
+    event1.logIndex = BigInt.fromU32(4);
+
+    handleAuthorizedSignerAdded(event1);
+
+    let authorizedSignerEntityId = buildAuthorizedSignerId(
+      subscriptionOwner,
+      authorizedSigner
+    );
+    assert.fieldEquals(
+      'AuthorizedSigner',
+      authorizedSignerEntityId.toHexString(),
+      'user',
+      user
+    );
+    assert.fieldEquals(
+      'AuthorizedSigner',
+      authorizedSignerEntityId.toHexString(),
+      'signer',
+      authorizedSigner.toHexString()
+    );
+
+    // should not readd the same authorized signer
+    let event2 = createAuthorizedSignerAddedEvent(
+      subscriptionOwner,
+      authorizedSigner
+    );
+    event2.logIndex = BigInt.fromU32(5);
+
+    handleAuthorizedSignerAdded(event2);
+
+    assert.entityCount('AuthorizedSigner', 1);
+  });
+
+  test('should be able to remove an AuthorizedSigner entity', () => {
+    assert.entityCount('AuthorizedSigner', 1);
+    // create another AuthorizedSigner
+    const signer2 = '0x0000000000000000000000000000000000000003';
+    let subscriptionOwner = Address.fromString(user);
+    let authorizedSigner2 = Address.fromString(signer2);
+    let authorizedSignerEntity2Id = buildAuthorizedSignerId(
+      subscriptionOwner,
+      authorizedSigner2
+    );
+    let addEvent = createAuthorizedSignerAddedEvent(
+      subscriptionOwner,
+      authorizedSigner2
+    );
+    addEvent.logIndex = BigInt.fromU32(6);
+
+    handleAuthorizedSignerAdded(addEvent);
+
+    assert.entityCount('AuthorizedSigner', 2);
+    assert.fieldEquals(
+      'AuthorizedSigner',
+      authorizedSignerEntity2Id.toHexString(),
+      'user',
+      user
+    );
+    assert.fieldEquals(
+      'AuthorizedSigner',
+      authorizedSignerEntity2Id.toHexString(),
+      'signer',
+      authorizedSigner2.toHexString()
+    );
+
+    // remove first AuthorizedSigner entity
+    const signer1 = '0x0000000000000000000000000000000000000002';
+    let authorizedSigner1 = Address.fromString(signer1);
+    let authorizedSignerEntity1Id = buildAuthorizedSignerId(
+      subscriptionOwner,
+      authorizedSigner1
+    );
+    let removeEvent = createAuthorizedSignerRemovedEvent(
+      subscriptionOwner,
+      Address.fromString(signer1)
+    );
+    removeEvent.logIndex = BigInt.fromU32(7);
+
+    handleAuthorizedSignerRemoved(removeEvent);
+
+    assert.entityCount('AuthorizedSigner', 1);
+    assert.notInStore(
+      'AuthorizedSigner',
+      authorizedSignerEntity1Id.toHexString()
     );
   });
 });

--- a/subgraph/yarn.lock
+++ b/subgraph/yarn.lock
@@ -1445,9 +1445,9 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-"gluegun@git+https://github.com/edgeandnode/gluegun.git#v4.3.1-pin-colors-dep":
+"gluegun@https://github.com/edgeandnode/gluegun#v4.3.1-pin-colors-dep":
   version "4.3.1"
-  resolved "git+https://github.com/edgeandnode/gluegun.git#b34b9003d7bf556836da41b57ef36eb21570620a"
+  resolved "https://github.com/edgeandnode/gluegun#b34b9003d7bf556836da41b57ef36eb21570620a"
   dependencies:
     apisauce "^1.0.1"
     app-module-path "^2.2.0"


### PR DESCRIPTION
# Description

Closes #14 

- Added a `AuthorizedSigner` entity to the subgraph schema and created a derived field on the `ActiveSubscription` entity: `authorizedSigners`
  - entity stores:
    - the user that is the owner of the `ActiveSubscritpion`
    - the authorized signer
- Added event mappings for the new `AuthorizedSignerAdded` and `AuthorizedSignerRemoved` events emitted by the contract
  - on: `AuthorizedSignerAdded`: create a `AuthorizedSigner` entity, associate it to the `ActiveSubscription`
  - on: `AuthorizedSignerRemoved`: remove the `AuthorizedSigner` entity
- the `id` of the `AuthorizedSigner` entity is a keccak256 of: `{ActiveSubscription.user}:{authorizedSigner}` hex string, converted to bytes