### PR TITLE
subgraph: Update event ABIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,23 @@ echo "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" | cargo 
     token
   }
   subscribes {
-    user
+    user { id }
     start
     end
     rate
   }
   unsubscribes {
-    user
+    user { id }
   }
   activeSubscriptions {
-    user
+    user { id }
     start
     end
     rate
+  }
+  users {
+    id
+    authorizedSigners { id }
   }
 }
 ```

--- a/subgraph/abis/Subscriptions.json
+++ b/subgraph/abis/Subscriptions.json
@@ -114,6 +114,49 @@
         "type": "address"
       },
       {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "epoch",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "start",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "end",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "rate",
+        "type": "uint128"
+      }
+    ],
+    "name": "PendingSubscriptionCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "epoch",
+        "type": "uint256"
+      },
+      {
         "indexed": false,
         "internalType": "uint64",
         "name": "start",
@@ -141,8 +184,45 @@
       {
         "indexed": true,
         "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "startEpoch",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "endEpoch",
+        "type": "uint256"
+      }
+    ],
+    "name": "TokensCollected",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "user",
         "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "epoch",
+        "type": "uint256"
       }
     ],
     "name": "Unsubscribe",
@@ -324,7 +404,7 @@
       },
       {
         "internalType": "uint256",
-        "name": "",
+        "name": "_amount",
         "type": "uint256"
       }
     ],
@@ -389,6 +469,35 @@
         "internalType": "address",
         "name": "",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "pendingSubscriptions",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "start",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "end",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint128",
+        "name": "rate",
+        "type": "uint128"
       }
     ],
     "stateMutability": "view",

--- a/subgraph/generated/Subscriptions/Subscriptions.ts
+++ b/subgraph/generated/Subscriptions/Subscriptions.ts
@@ -116,6 +116,40 @@ export class OwnershipTransferred__Params {
   }
 }
 
+export class PendingSubscriptionCreated extends ethereum.Event {
+  get params(): PendingSubscriptionCreated__Params {
+    return new PendingSubscriptionCreated__Params(this);
+  }
+}
+
+export class PendingSubscriptionCreated__Params {
+  _event: PendingSubscriptionCreated;
+
+  constructor(event: PendingSubscriptionCreated) {
+    this._event = event;
+  }
+
+  get user(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get epoch(): BigInt {
+    return this._event.parameters[1].value.toBigInt();
+  }
+
+  get start(): BigInt {
+    return this._event.parameters[2].value.toBigInt();
+  }
+
+  get end(): BigInt {
+    return this._event.parameters[3].value.toBigInt();
+  }
+
+  get rate(): BigInt {
+    return this._event.parameters[4].value.toBigInt();
+  }
+}
+
 export class Subscribe extends ethereum.Event {
   get params(): Subscribe__Params {
     return new Subscribe__Params(this);
@@ -133,15 +167,49 @@ export class Subscribe__Params {
     return this._event.parameters[0].value.toAddress();
   }
 
-  get start(): BigInt {
+  get epoch(): BigInt {
     return this._event.parameters[1].value.toBigInt();
   }
 
-  get end(): BigInt {
+  get start(): BigInt {
     return this._event.parameters[2].value.toBigInt();
   }
 
+  get end(): BigInt {
+    return this._event.parameters[3].value.toBigInt();
+  }
+
   get rate(): BigInt {
+    return this._event.parameters[4].value.toBigInt();
+  }
+}
+
+export class TokensCollected extends ethereum.Event {
+  get params(): TokensCollected__Params {
+    return new TokensCollected__Params(this);
+  }
+}
+
+export class TokensCollected__Params {
+  _event: TokensCollected;
+
+  constructor(event: TokensCollected) {
+    this._event = event;
+  }
+
+  get owner(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get amount(): BigInt {
+    return this._event.parameters[1].value.toBigInt();
+  }
+
+  get startEpoch(): BigInt {
+    return this._event.parameters[2].value.toBigInt();
+  }
+
+  get endEpoch(): BigInt {
     return this._event.parameters[3].value.toBigInt();
   }
 }
@@ -161,6 +229,10 @@ export class Unsubscribe__Params {
 
   get user(): Address {
     return this._event.parameters[0].value.toAddress();
+  }
+
+  get epoch(): BigInt {
+    return this._event.parameters[1].value.toBigInt();
   }
 }
 
@@ -186,6 +258,38 @@ export class Subscriptions__epochsResult {
 
   getExtra(): BigInt {
     return this.value1;
+  }
+}
+
+export class Subscriptions__pendingSubscriptionsResult {
+  value0: BigInt;
+  value1: BigInt;
+  value2: BigInt;
+
+  constructor(value0: BigInt, value1: BigInt, value2: BigInt) {
+    this.value0 = value0;
+    this.value1 = value1;
+    this.value2 = value2;
+  }
+
+  toMap(): TypedMap<string, ethereum.Value> {
+    let map = new TypedMap<string, ethereum.Value>();
+    map.set("value0", ethereum.Value.fromUnsignedBigInt(this.value0));
+    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1));
+    map.set("value2", ethereum.Value.fromUnsignedBigInt(this.value2));
+    return map;
+  }
+
+  getStart(): BigInt {
+    return this.value0;
+  }
+
+  getEnd(): BigInt {
+    return this.value1;
+  }
+
+  getRate(): BigInt {
+    return this.value2;
   }
 }
 
@@ -422,6 +526,43 @@ export class Subscriptions extends ethereum.SmartContract {
     }
     let value = result.value;
     return ethereum.CallResult.fromValue(value[0].toAddress());
+  }
+
+  pendingSubscriptions(
+    param0: Address
+  ): Subscriptions__pendingSubscriptionsResult {
+    let result = super.call(
+      "pendingSubscriptions",
+      "pendingSubscriptions(address):(uint64,uint64,uint128)",
+      [ethereum.Value.fromAddress(param0)]
+    );
+
+    return new Subscriptions__pendingSubscriptionsResult(
+      result[0].toBigInt(),
+      result[1].toBigInt(),
+      result[2].toBigInt()
+    );
+  }
+
+  try_pendingSubscriptions(
+    param0: Address
+  ): ethereum.CallResult<Subscriptions__pendingSubscriptionsResult> {
+    let result = super.tryCall(
+      "pendingSubscriptions",
+      "pendingSubscriptions(address):(uint64,uint64,uint128)",
+      [ethereum.Value.fromAddress(param0)]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(
+      new Subscriptions__pendingSubscriptionsResult(
+        value[0].toBigInt(),
+        value[1].toBigInt(),
+        value[2].toBigInt()
+      )
+    );
   }
 
   subscriptions(param0: Address): Subscriptions__subscriptionsResult {
@@ -754,7 +895,7 @@ export class FulfilCall__Inputs {
     return this._call.inputValues[0].value.toAddress();
   }
 
-  get value1(): BigInt {
+  get _amount(): BigInt {
     return this._call.inputValues[1].value.toBigInt();
   }
 }

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -24,9 +24,9 @@ dataSources:
       eventHandlers:
         - event: Init(address)
           handler: handleInit
-        - event: Subscribe(indexed address,uint64,uint64,uint128)
+        - event: Subscribe(indexed address,indexed uint256,uint64,uint64,uint128)
           handler: handleSubscribe
-        - event: Unsubscribe(indexed address)
+        - event: Unsubscribe(indexed address,indexed uint256)
           handler: handleUnsubscribe
         - event: AuthorizedSignerAdded(indexed address,indexed address)
           handler: handleAuthorizedSignerAdded

--- a/subgraph/tests/subscriptions-utils.ts
+++ b/subgraph/tests/subscriptions-utils.ts
@@ -9,9 +9,10 @@ import {
 } from '../generated/Subscriptions/Subscriptions';
 
 export function createSubscribeEvent(
-  subscriber: Address,
-  startBlock: BigInt,
-  endBlock: BigInt,
+  user: Address,
+  epoch: BigInt,
+  start: BigInt,
+  end: BigInt,
   pricePerBlock: BigInt
 ): Subscribe {
   let subscribeEvent = changetype<Subscribe>(newMockEvent());
@@ -19,22 +20,16 @@ export function createSubscribeEvent(
   subscribeEvent.parameters = new Array();
 
   subscribeEvent.parameters.push(
-    new ethereum.EventParam(
-      'subscriber',
-      ethereum.Value.fromAddress(subscriber)
-    )
+    new ethereum.EventParam('user', ethereum.Value.fromAddress(user))
   );
   subscribeEvent.parameters.push(
-    new ethereum.EventParam(
-      'startBlock',
-      ethereum.Value.fromUnsignedBigInt(startBlock)
-    )
+    new ethereum.EventParam('epoch', ethereum.Value.fromUnsignedBigInt(epoch))
   );
   subscribeEvent.parameters.push(
-    new ethereum.EventParam(
-      'endBlock',
-      ethereum.Value.fromUnsignedBigInt(endBlock)
-    )
+    new ethereum.EventParam('start', ethereum.Value.fromUnsignedBigInt(start))
+  );
+  subscribeEvent.parameters.push(
+    new ethereum.EventParam('end', ethereum.Value.fromUnsignedBigInt(end))
   );
   subscribeEvent.parameters.push(
     new ethereum.EventParam(
@@ -46,40 +41,34 @@ export function createSubscribeEvent(
   return subscribeEvent;
 }
 
-export function createUnsubscribeEvent(subscriber: Address): Unsubscribe {
+export function createUnsubscribeEvent(
+  user: Address,
+  epoch: BigInt
+): Unsubscribe {
   let unsubscribeEvent = changetype<Unsubscribe>(newMockEvent());
 
   unsubscribeEvent.parameters = new Array();
 
   unsubscribeEvent.parameters.push(
-    new ethereum.EventParam(
-      'subscriber',
-      ethereum.Value.fromAddress(subscriber)
-    )
+    new ethereum.EventParam('user', ethereum.Value.fromAddress(user))
+  );
+  unsubscribeEvent.parameters.push(
+    new ethereum.EventParam('epoch', ethereum.Value.fromUnsignedBigInt(epoch))
   );
 
   return unsubscribeEvent;
 }
 
-export function createExtendEvent(
-  subscriber: Address,
-  endBlock: BigInt
-): Extend {
+export function createExtendEvent(user: Address, end: BigInt): Extend {
   let extendEvent = changetype<Extend>(newMockEvent());
 
   extendEvent.parameters = new Array();
 
   extendEvent.parameters.push(
-    new ethereum.EventParam(
-      'subscriber',
-      ethereum.Value.fromAddress(subscriber)
-    )
+    new ethereum.EventParam('user', ethereum.Value.fromAddress(user))
   );
   extendEvent.parameters.push(
-    new ethereum.EventParam(
-      'endBlock',
-      ethereum.Value.fromUnsignedBigInt(endBlock)
-    )
+    new ethereum.EventParam('end', ethereum.Value.fromUnsignedBigInt(end))
   );
 
   return extendEvent;

--- a/subgraph/tests/subscriptions.test.ts
+++ b/subgraph/tests/subscriptions.test.ts
@@ -34,6 +34,7 @@ describe('Describe entity assertions', () => {
   beforeAll(() => {
     let event = createSubscribeEvent(
       Address.fromString(user),
+      BigInt.fromU32(0),
       BigInt.fromU32(2000),
       BigInt.fromU32(5000),
       BigInt.fromU32(10)
@@ -72,7 +73,10 @@ describe('Describe entity assertions', () => {
   });
 
   test('handle Unsubscribe', () => {
-    let event = createUnsubscribeEvent(Address.fromString(user));
+    let event = createUnsubscribeEvent(
+      Address.fromString(user),
+      BigInt.fromU32(0)
+    );
     handleUnsubscribe(event);
 
     assert.entityCount('Subscribe', 1);
@@ -83,6 +87,7 @@ describe('Describe entity assertions', () => {
   test('update Subscription', () => {
     let event = createSubscribeEvent(
       Address.fromString(user),
+      BigInt.fromU32(0),
       BigInt.fromU32(3000),
       BigInt.fromU32(8000),
       BigInt.fromU32(10)


### PR DESCRIPTION
It would be nice to have `graph codegen` run using the abi file from `contract/build/` instead of having to copy it over to the subgraph repo to keep it in sync. But I'm not sure that the codegen tool supports different paths.