### PR TITLE
Preserve Subscription on Unsubscribe, fix derived events

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+subgraph/generated/**

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,4 @@
+/** @type {import('prettier').Options} */
 module.exports = {
   bracketSpacing: false,
   jsxBracketSameLine: true,

--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ echo "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" | cargo 
   unsubscribes {
     user { id }
   }
-  subscriptions {
+  userSubscriptions {
     user { id }
     start
     end
     rate
+    cancelled
   }
   users {
     id

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ echo "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" | cargo 
   unsubscribes {
     user { id }
   }
-  activeSubscriptions {
+  subscriptions {
     user { id }
     start
     end

--- a/subgraph/generated/schema.ts
+++ b/subgraph/generated/schema.ts
@@ -153,8 +153,8 @@ export class User extends Entity {
     }
   }
 
-  get activeSubscriptions(): Array<Bytes> | null {
-    let value = this.get("activeSubscriptions");
+  get subscriptions(): Array<Bytes> | null {
+    let value = this.get("subscriptions");
     if (!value || value.kind == ValueKind.NULL) {
       return null;
     } else {
@@ -162,12 +162,12 @@ export class User extends Entity {
     }
   }
 
-  set activeSubscriptions(value: Array<Bytes> | null) {
+  set subscriptions(value: Array<Bytes> | null) {
     if (!value) {
-      this.unset("activeSubscriptions");
+      this.unset("subscriptions");
     } else {
       this.set(
-        "activeSubscriptions",
+        "subscriptions",
         Value.fromBytesArray(<Array<Bytes>>value)
       );
     }
@@ -461,7 +461,7 @@ export class Extend extends Entity {
   }
 }
 
-export class ActiveSubscription extends Entity {
+export class Subscription extends Entity {
   constructor(id: Bytes) {
     super();
     this.set("id", Value.fromBytes(id));
@@ -469,19 +469,19 @@ export class ActiveSubscription extends Entity {
 
   save(): void {
     let id = this.get("id");
-    assert(id != null, "Cannot save ActiveSubscription entity without an ID");
+    assert(id != null, "Cannot save Subscription entity without an ID");
     if (id) {
       assert(
         id.kind == ValueKind.BYTES,
-        `Entities of type ActiveSubscription must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`
+        `Entities of type Subscription must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`
       );
-      store.set("ActiveSubscription", id.toBytes().toHexString(), this);
+      store.set("Subscription", id.toBytes().toHexString(), this);
     }
   }
 
-  static load(id: Bytes): ActiveSubscription | null {
-    return changetype<ActiveSubscription | null>(
-      store.get("ActiveSubscription", id.toHexString())
+  static load(id: Bytes): Subscription | null {
+    return changetype<Subscription | null>(
+      store.get("Subscription", id.toHexString())
     );
   }
 

--- a/subgraph/generated/schema.ts
+++ b/subgraph/generated/schema.ts
@@ -166,10 +166,7 @@ export class User extends Entity {
     if (!value) {
       this.unset("subscriptions");
     } else {
-      this.set(
-        "subscriptions",
-        Value.fromBytesArray(<Array<Bytes>>value)
-      );
+      this.set("subscriptions", Value.fromBytesArray(<Array<Bytes>>value));
     }
   }
 
@@ -528,6 +525,15 @@ export class Subscription extends Entity {
 
   set rate(value: BigInt) {
     this.set("rate", Value.fromBigInt(value));
+  }
+
+  get cancelled(): boolean {
+    let value = this.get("cancelled");
+    return value!.toBoolean();
+  }
+
+  set cancelled(value: boolean) {
+    this.set("cancelled", Value.fromBoolean(value));
   }
 }
 

--- a/subgraph/generated/schema.ts
+++ b/subgraph/generated/schema.ts
@@ -153,8 +153,8 @@ export class User extends Entity {
     }
   }
 
-  get subscriptions(): Array<Bytes> | null {
-    let value = this.get("subscriptions");
+  get userSubscriptions(): Array<Bytes> | null {
+    let value = this.get("userSubscriptions");
     if (!value || value.kind == ValueKind.NULL) {
       return null;
     } else {
@@ -162,11 +162,11 @@ export class User extends Entity {
     }
   }
 
-  set subscriptions(value: Array<Bytes> | null) {
+  set userSubscriptions(value: Array<Bytes> | null) {
     if (!value) {
-      this.unset("subscriptions");
+      this.unset("userSubscriptions");
     } else {
-      this.set("subscriptions", Value.fromBytesArray(<Array<Bytes>>value));
+      this.set("userSubscriptions", Value.fromBytesArray(<Array<Bytes>>value));
     }
   }
 
@@ -458,7 +458,7 @@ export class Extend extends Entity {
   }
 }
 
-export class Subscription extends Entity {
+export class UserSubscription extends Entity {
   constructor(id: Bytes) {
     super();
     this.set("id", Value.fromBytes(id));
@@ -466,19 +466,19 @@ export class Subscription extends Entity {
 
   save(): void {
     let id = this.get("id");
-    assert(id != null, "Cannot save Subscription entity without an ID");
+    assert(id != null, "Cannot save UserSubscription entity without an ID");
     if (id) {
       assert(
         id.kind == ValueKind.BYTES,
-        `Entities of type Subscription must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`
+        `Entities of type UserSubscription must have an ID of type Bytes but the id '${id.displayData()}' is of type ${id.displayKind()}`
       );
-      store.set("Subscription", id.toBytes().toHexString(), this);
+      store.set("UserSubscription", id.toBytes().toHexString(), this);
     }
   }
 
-  static load(id: Bytes): Subscription | null {
-    return changetype<Subscription | null>(
-      store.get("Subscription", id.toHexString())
+  static load(id: Bytes): UserSubscription | null {
+    return changetype<UserSubscription | null>(
+      store.get("UserSubscription", id.toHexString())
     );
   }
 

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -11,7 +11,7 @@ type User @entity {
   subscribeEvents: [Subscribe!]! @derivedFrom(field: "user") # can't have a User with a subscribe
   unsubscribeEvents: [Unsubscribe!] @derivedFrom(field: "user")
   extendEvents: [Unsubscribe!] @derivedFrom(field: "user")
-  subscriptions: [Subscription!] @derivedFrom(field: "user")
+  userSubscriptions: [UserSubscription!] @derivedFrom(field: "user")
   authorizedSigners: [AuthorizedSigner!] @derivedFrom(field: "user")
   # a total count of all events of all types. useful for pagination
   eventCount: Int!
@@ -46,14 +46,14 @@ type Extend @entity(immutable: true) {
   end: BigInt! # uint64
 }
 
-type Subscription @entity {
+type UserSubscription @entity {
   id: Bytes!
   user: User!
   start: BigInt! # uint64
   end: BigInt! # uint64
   rate: BigInt! # uint128
-  # The subgraph preserves `end` timestamp of cancelled subscriptions to enable showing it in UI
-  # Even if not cancelled an expired subscription is inactive.
+  # The subgraph preserves `end` timestamp of cancelled UserSubscriptions to enable showing it in UI
+  # Even if not cancelled an expired UserSubscription is inactive.
   cancelled: Boolean!
 }
 
@@ -64,30 +64,30 @@ type AuthorizedSigner @entity {
 }
 
 """
-Enum of available User Subscription Event types based off the action the user performed
+Enum of available User UserSubscription Event types based off the action the user performed
 """
 enum UserSubscriptionsEventType {
-  # The user created a net-new Subscription
+  # The user created a net-new UserSubscription
   CREATED
-  # The user canceled their active Subscription
+  # The user canceled their active UserSubscription
   CANCELED
-  # The user renewed (extended the ending timestamp) of their active Subscription
+  # The user renewed (extended the ending timestamp) of their active UserSubscription
   RENEW
-  # The user upgraded (set the rate to a higher value -> more queries available) of their active Subscription
+  # The user upgraded (set the rate to a higher value -> more queries available) of their active UserSubscription
   UPGRADE
-  # The user downgraded (set the rate to a lower value -> less queries available) of their active Subscription
+  # The user downgraded (set the rate to a lower value -> less queries available) of their active UserSubscription
   DOWNGRADE
 }
 
 """
-Generic interface that maps user events in the Subscriptions contract.
+Generic interface that maps user events in the UserSubscriptions contract.
 
 Some example events:
-- User creates a net-new subscription -> UserSubscriptionCreatedEvent
-- User cancels their active subscription -> UserSubscriptionCanceledEvent
-- User renews their active subscription -> UserSubscriptionRenewalEvent
-- User upgrades their active subscription -> UserSubscriptionUpgradeEvent
-- User downgrades their active subscription -> UserSubscriptionDowngradeEvent
+- User creates a net-new UserSubscription -> UserSubscriptionCreatedEvent
+- User cancels their active UserSubscription -> UserSubscriptionCanceledEvent
+- User renews their active UserSubscription -> UserSubscriptionRenewalEvent
+- User upgrades their active UserSubscription -> UserSubscriptionUpgradeEvent
+- User downgrades their active UserSubscription -> UserSubscriptionDowngradeEvent
 """
 interface UserSubscriptionsEvent {
   # keccak256 hex string of user:{event type}:txHash
@@ -100,7 +100,7 @@ interface UserSubscriptionsEvent {
 }
 
 """
-User created a net-new active Subscription
+User created a net-new active UserSubscription
 """
 type UserSubscriptionCreatedEvent implements UserSubscriptionsEvent
   @entity(immutable: true) {
@@ -112,16 +112,16 @@ type UserSubscriptionCreatedEvent implements UserSubscriptionsEvent
   txHash: Bytes!
   # will always be UserSubscriptionsEventType.CREATED
   eventType: UserSubscriptionsEventType!
-  # the user's Subscription.start value at the time the event is created
+  # the user's UserSubscription.start value at the time the event is created
   currentSubscriptionStart: BigInt! # uint64
-  # the user's Subscription.end value at the time the event is created
+  # the user's UserSubscription.end value at the time the event is created
   currentSubscriptionEnd: BigInt! # uint64
-  # the user's Subscription.rate value at the time the event is created
+  # the user's UserSubscription.rate value at the time the event is created
   currentSubscriptionRate: BigInt! # uint128
 }
 
 """
-User canceled their active subscription
+User canceled their active UserSubscription
 """
 type UserSubscriptionCanceledEvent implements UserSubscriptionsEvent
   @entity(immutable: true) {
@@ -133,14 +133,14 @@ type UserSubscriptionCanceledEvent implements UserSubscriptionsEvent
   txHash: Bytes!
   # will always be UserSubscriptionsEventType.CANCELED
   eventType: UserSubscriptionsEventType!
-  # the amount of unlocked tokens transferred back to the user as a result of cancelling the Subscription
+  # the amount of unlocked tokens transferred back to the user as a result of cancelling the UserSubscription
   tokensReturned: BigInt!
 }
 
 """
-User renewed their active Subscription.
+User renewed their active UserSubscription.
 
-Renewing means that the user extended the end timestamp of their active Subscription to a later timestamp.
+Renewing means that the user extended the end timestamp of their active UserSubscription to a later timestamp.
 """
 type UserSubscriptionRenewalEvent implements UserSubscriptionsEvent
   @entity(immutable: true) {
@@ -152,18 +152,18 @@ type UserSubscriptionRenewalEvent implements UserSubscriptionsEvent
   txHash: Bytes!
   # will always be UserSubscriptionsEventType.RENEW
   eventType: UserSubscriptionsEventType!
-  # the user's Subscription.start value at the time the event is created
+  # the user's UserSubscription.start value at the time the event is created
   currentSubscriptionStart: BigInt! # uint64
-  # the user's Subscription.end value at the time the event is created
+  # the user's UserSubscription.end value at the time the event is created
   currentSubscriptionEnd: BigInt! # uint64
-  # the user's Subscription.rate value at the time the event is created
+  # the user's UserSubscription.rate value at the time the event is created
   currentSubscriptionRate: BigInt! # uint128
 }
 
 """
-User upgraded their active Subscription.
+User upgraded their active UserSubscription.
 
-Upgrading means that the user increased the `rate` on their active Subscription, granting them more query volume.
+Upgrading means that the user increased the `rate` on their active UserSubscription, granting them more query volume.
 """
 type UserSubscriptionUpgradeEvent implements UserSubscriptionsEvent
   @entity(immutable: true) {
@@ -175,24 +175,24 @@ type UserSubscriptionUpgradeEvent implements UserSubscriptionsEvent
   txHash: Bytes!
   # will always be UserSubscriptionsEventType.UPGRADE
   eventType: UserSubscriptionsEventType!
-  # the Subscription.start value before the user upgraded their subscription
+  # the UserSubscription.start value before the user upgraded their UserSubscription
   previousSubscriptionStart: BigInt! # uint64
-  # the Subscription.end value before the user upgraded their subscription
+  # the UserSubscription.end value before the user upgraded their UserSubscription
   previousSubscriptionEnd: BigInt! # uint64
-  # the Subscription.rate value before the user upgraded their subscription
+  # the UserSubscription.rate value before the user upgraded their UserSubscription
   previousSubscriptionRate: BigInt! # uint128
-  # the user's Subscription.start value at the time the event is created
+  # the user's UserSubscription.start value at the time the event is created
   currentSubscriptionStart: BigInt! # uint64
-  # the user's Subscription.end value at the time the event is created
+  # the user's UserSubscription.end value at the time the event is created
   currentSubscriptionEnd: BigInt! # uint64
-  # the user's Subscription.rate value at the time the event is created
+  # the user's UserSubscription.rate value at the time the event is created
   currentSubscriptionRate: BigInt! # uint128
 }
 
 """
-User downgraded their active Subscription.
+User downgraded their active UserSubscription.
 
-Downgrading means that the user decreased the `rate` on their active Subscription, granting them less query volume.
+Downgrading means that the user decreased the `rate` on their active UserSubscription, granting them less query volume.
 """
 type UserSubscriptionDowngradeEvent implements UserSubscriptionsEvent
   @entity(immutable: true) {
@@ -204,16 +204,16 @@ type UserSubscriptionDowngradeEvent implements UserSubscriptionsEvent
   txHash: Bytes!
   # will always be UserSubscriptionsEventType.DOWNGRADE
   eventType: UserSubscriptionsEventType!
-  # the Subscription.start value before the user downgraded their subscription
+  # the UserSubscription.start value before the user downgraded their UserSubscription
   previousSubscriptionStart: BigInt! # uint64
-  # the Subscription.end value before the user downgraded their subscription
+  # the UserSubscription.end value before the user downgraded their UserSubscription
   previousSubscriptionEnd: BigInt! # uint64
-  # the Subscription.rate value before the user downgraded their subscription
+  # the UserSubscription.rate value before the user downgraded their UserSubscription
   previousSubscriptionRate: BigInt! # uint128
-  # the user's Subscription.start value at the time the event is created
+  # the user's UserSubscription.start value at the time the event is created
   currentSubscriptionStart: BigInt! # uint64
-  # the user's Subscription.end value at the time the event is created
+  # the user's UserSubscription.end value at the time the event is created
   currentSubscriptionEnd: BigInt! # uint64
-  # the user's Subscription.rate value at the time the event is created
+  # the user's UserSubscription.rate value at the time the event is created
   currentSubscriptionRate: BigInt! # uint128
 }

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -52,6 +52,9 @@ type Subscription @entity {
   start: BigInt! # uint64
   end: BigInt! # uint64
   rate: BigInt! # uint128
+  # The subgraph preserves `end` timestamp of cancelled subscriptions to enable showing it in UI
+  # Even if not cancelled an expired subscription is inactive.
+  cancelled: Boolean!
 }
 
 type AuthorizedSigner @entity {

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -11,7 +11,7 @@ type User @entity {
   subscribeEvents: [Subscribe!]! @derivedFrom(field: "user") # can't have a User with a subscribe
   unsubscribeEvents: [Unsubscribe!] @derivedFrom(field: "user")
   extendEvents: [Unsubscribe!] @derivedFrom(field: "user")
-  activeSubscriptions: [ActiveSubscription!] @derivedFrom(field: "user")
+  subscriptions: [Subscription!] @derivedFrom(field: "user")
   authorizedSigners: [AuthorizedSigner!] @derivedFrom(field: "user")
   # a total count of all events of all types. useful for pagination
   eventCount: Int!
@@ -46,7 +46,7 @@ type Extend @entity(immutable: true) {
   end: BigInt! # uint64
 }
 
-type ActiveSubscription @entity {
+type Subscription @entity {
   id: Bytes!
   user: User!
   start: BigInt! # uint64
@@ -109,11 +109,11 @@ type UserSubscriptionCreatedEvent implements UserSubscriptionsEvent
   txHash: Bytes!
   # will always be UserSubscriptionsEventType.CREATED
   eventType: UserSubscriptionsEventType!
-  # the user's ActiveSubscription.start value at the time the event is created
+  # the user's Subscription.start value at the time the event is created
   currentSubscriptionStart: BigInt! # uint64
-  # the user's ActiveSubscription.end value at the time the event is created
+  # the user's Subscription.end value at the time the event is created
   currentSubscriptionEnd: BigInt! # uint64
-  # the user's ActiveSubscription.rate value at the time the event is created
+  # the user's Subscription.rate value at the time the event is created
   currentSubscriptionRate: BigInt! # uint128
 }
 
@@ -130,7 +130,7 @@ type UserSubscriptionCanceledEvent implements UserSubscriptionsEvent
   txHash: Bytes!
   # will always be UserSubscriptionsEventType.CANCELED
   eventType: UserSubscriptionsEventType!
-  # the amount of unlocked tokens transferred back to the user as a result of cancelling the ActiveSubscription
+  # the amount of unlocked tokens transferred back to the user as a result of cancelling the Subscription
   tokensReturned: BigInt!
 }
 
@@ -149,11 +149,11 @@ type UserSubscriptionRenewalEvent implements UserSubscriptionsEvent
   txHash: Bytes!
   # will always be UserSubscriptionsEventType.RENEW
   eventType: UserSubscriptionsEventType!
-  # the user's ActiveSubscription.start value at the time the event is created
+  # the user's Subscription.start value at the time the event is created
   currentSubscriptionStart: BigInt! # uint64
-  # the user's ActiveSubscription.end value at the time the event is created
+  # the user's Subscription.end value at the time the event is created
   currentSubscriptionEnd: BigInt! # uint64
-  # the user's ActiveSubscription.rate value at the time the event is created
+  # the user's Subscription.rate value at the time the event is created
   currentSubscriptionRate: BigInt! # uint128
 }
 
@@ -172,17 +172,17 @@ type UserSubscriptionUpgradeEvent implements UserSubscriptionsEvent
   txHash: Bytes!
   # will always be UserSubscriptionsEventType.UPGRADE
   eventType: UserSubscriptionsEventType!
-  # the ActiveSubscription.start value before the user upgraded their subscription
+  # the Subscription.start value before the user upgraded their subscription
   previousSubscriptionStart: BigInt! # uint64
-  # the ActiveSubscription.end value before the user upgraded their subscription
+  # the Subscription.end value before the user upgraded their subscription
   previousSubscriptionEnd: BigInt! # uint64
-  # the ActiveSubscription.rate value before the user upgraded their subscription
+  # the Subscription.rate value before the user upgraded their subscription
   previousSubscriptionRate: BigInt! # uint128
-  # the user's ActiveSubscription.start value at the time the event is created
+  # the user's Subscription.start value at the time the event is created
   currentSubscriptionStart: BigInt! # uint64
-  # the user's ActiveSubscription.end value at the time the event is created
+  # the user's Subscription.end value at the time the event is created
   currentSubscriptionEnd: BigInt! # uint64
-  # the user's ActiveSubscription.rate value at the time the event is created
+  # the user's Subscription.rate value at the time the event is created
   currentSubscriptionRate: BigInt! # uint128
 }
 
@@ -201,16 +201,16 @@ type UserSubscriptionDowngradeEvent implements UserSubscriptionsEvent
   txHash: Bytes!
   # will always be UserSubscriptionsEventType.DOWNGRADE
   eventType: UserSubscriptionsEventType!
-  # the ActiveSubscription.start value before the user downgraded their subscription
+  # the Subscription.start value before the user downgraded their subscription
   previousSubscriptionStart: BigInt! # uint64
-  # the ActiveSubscription.end value before the user downgraded their subscription
+  # the Subscription.end value before the user downgraded their subscription
   previousSubscriptionEnd: BigInt! # uint64
-  # the ActiveSubscription.rate value before the user downgraded their subscription
+  # the Subscription.rate value before the user downgraded their subscription
   previousSubscriptionRate: BigInt! # uint128
-  # the user's ActiveSubscription.start value at the time the event is created
+  # the user's Subscription.start value at the time the event is created
   currentSubscriptionStart: BigInt! # uint64
-  # the user's ActiveSubscription.end value at the time the event is created
+  # the user's Subscription.end value at the time the event is created
   currentSubscriptionEnd: BigInt! # uint64
-  # the user's ActiveSubscription.rate value at the time the event is created
+  # the user's Subscription.rate value at the time the event is created
   currentSubscriptionRate: BigInt! # uint128
 }

--- a/subgraph/src/subscriptions.ts
+++ b/subgraph/src/subscriptions.ts
@@ -1,4 +1,4 @@
-import {BigInt, store} from '@graphprotocol/graph-ts';
+import {store} from '@graphprotocol/graph-ts';
 
 import {
   Init as InitEvent,
@@ -129,7 +129,10 @@ export function handleUnsubscribe(event: UnsubscribeEvent): void {
 
   // To handle an edge-case where the Subscribe/Unsubscribe events aren't received by the subgraph mapping in the same order they are emitted,
   // if a `UserSubscriptionCreatedEvent` exists in the same timestamp, don't create the `UserSubscriptionCanceledEvent` record
-  let subscribeEvent = Subscribe.load(event.transaction.hash);
+  let subscribeEvent = Subscribe.load(
+    event.transaction.hash.concatI32(event.logIndex.toI32())
+  );
+
   if (subscribeEvent != null) return;
 
   buildAndSaveUserSubscriptionCanceledEvent(user, sub, event);

--- a/subgraph/src/subscriptions.ts
+++ b/subgraph/src/subscriptions.ts
@@ -8,7 +8,7 @@ import {
   AuthorizedSignerRemoved as AuthorizedSignerRemovedEvent,
 } from '../generated/Subscriptions/Subscriptions';
 import {
-  Subscription,
+  UserSubscription,
   Init,
   Subscribe,
   Unsubscribe,
@@ -61,9 +61,9 @@ export function handleSubscribe(event: SubscribeEvent): void {
 
   let user = loadOrCreateUser(event.params.user);
 
-  let sub = Subscription.load(event.params.user);
+  let sub = UserSubscription.load(event.params.user);
   if (sub == null) {
-    sub = new Subscription(event.params.user);
+    sub = new UserSubscription(event.params.user);
     sub.user = user.id;
     sub.start = event.params.start;
     sub.end = event.params.end;
@@ -124,7 +124,7 @@ export function handleUnsubscribe(event: UnsubscribeEvent): void {
   entity.user = user.id;
   entity.save();
 
-  let sub = Subscription.load(event.params.user);
+  let sub = UserSubscription.load(event.params.user);
   if (sub == null) return;
 
   // To handle an edge-case where the Subscribe/Unsubscribe events aren't received by the subgraph mapping in the same order they are emitted,
@@ -172,7 +172,7 @@ export function handleAuthorizedSignerRemoved(
 
 function buildAndSaveUserSubscriptionCreatedEvent(
   user: User,
-  sub: Subscription,
+  sub: UserSubscription,
   event: SubscribeEvent
 ): void {
   let id = buildUserSubscriptionEventId(
@@ -199,7 +199,7 @@ function buildAndSaveUserSubscriptionCreatedEvent(
 
 function buildAndSaveUserSubscriptionCanceledEvent(
   user: User,
-  sub: Subscription,
+  sub: UserSubscription,
   event: UnsubscribeEvent
 ): void {
   let id = buildUserSubscriptionEventId(
@@ -221,7 +221,7 @@ function buildAndSaveUserSubscriptionCanceledEvent(
 
 function buildAndSaveUserSubscriptionRenewalEvent(
   user: User,
-  sub: Subscription,
+  sub: UserSubscription,
   event: SubscribeEvent
 ): void {
   let id = buildUserSubscriptionEventId(
@@ -245,7 +245,7 @@ function buildAndSaveUserSubscriptionRenewalEvent(
 
 function buildAndSaveUserSubscriptionUpgradeEvent(
   user: User,
-  sub: Subscription,
+  sub: UserSubscription,
   event: SubscribeEvent
 ): void {
   let id = buildUserSubscriptionEventId(
@@ -272,7 +272,7 @@ function buildAndSaveUserSubscriptionUpgradeEvent(
 
 function buildAndSaveUserSubscriptionDowngradeEvent(
   user: User,
-  sub: Subscription,
+  sub: UserSubscription,
   event: SubscribeEvent
 ): void {
   let id = buildUserSubscriptionEventId(

--- a/subgraph/src/utils.ts
+++ b/subgraph/src/utils.ts
@@ -6,13 +6,13 @@ import {
   crypto,
 } from '@graphprotocol/graph-ts';
 
-import {ActiveSubscription} from '../generated/schema';
+import {Subscription} from '../generated/schema';
 import {Unsubscribe as UnsubscribeEvent} from '../generated/Subscriptions/Subscriptions';
 
 /**
  * Generate a keccak256 hex string of the user:authorizedSigner
- * @param subscriptionOwner address of the ActiveSubscription owner
- * @param authorizedSigner address of the user authorized to sign for the owner of the ActiveSubscription
+ * @param subscriptionOwner address of the Subscription owner
+ * @param authorizedSigner address of the user authorized to sign for the owner of the Subscription
  * @returns Bytes representation of a hex string concatenation of the `user:authorizedSigner` to create a unique id
  */
 export function buildAuthorizedSignerId(
@@ -46,10 +46,10 @@ export function buildUserSubscriptionEventId(
 }
 
 /**
- * Calculate the unlocked tokens being returned to the User for cancelling their ActiveSubscription.
+ * Calculate the unlocked tokens being returned to the User for cancelling their Subscription.
  */
 export function calculateUnlockedTokens(
-  sub: ActiveSubscription,
+  sub: Subscription,
   event: UnsubscribeEvent
 ): BigInt {
   let correctedStart = event.block.timestamp;

--- a/subgraph/src/utils.ts
+++ b/subgraph/src/utils.ts
@@ -6,7 +6,7 @@ import {
   crypto,
 } from '@graphprotocol/graph-ts';
 
-import {Subscription} from '../generated/schema';
+import {UserSubscription} from '../generated/schema';
 import {Unsubscribe as UnsubscribeEvent} from '../generated/Subscriptions/Subscriptions';
 
 /**
@@ -49,7 +49,7 @@ export function buildUserSubscriptionEventId(
  * Calculate the unlocked tokens being returned to the User for cancelling their Subscription.
  */
 export function calculateUnlockedTokens(
-  sub: Subscription,
+  sub: UserSubscription,
   event: UnsubscribeEvent
 ): BigInt {
   let correctedStart = event.block.timestamp;

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -16,7 +16,7 @@ dataSources:
         - Init
         - Subscribe
         - Unsubscribe
-        - ActiveSubscription
+        - Subscription
       abis:
         - name: Subscriptions
           file: ./abis/Subscriptions.json

--- a/subgraph/tests/block-utils.ts
+++ b/subgraph/tests/block-utils.ts
@@ -1,0 +1,66 @@
+import {Address, Bytes, BigInt, ethereum} from '@graphprotocol/graph-ts';
+
+let defaultAddress = Address.fromString(
+  '0xA16081F360e3847006dB660bae1c6d1b2e17eC2A'
+);
+let defaultAddressBytes = defaultAddress as Bytes;
+let defaultBigInt = BigInt.fromI32(1);
+
+function firstBlock(): ethereum.Block {
+  return new ethereum.Block(
+    defaultAddressBytes,
+    defaultAddressBytes,
+    defaultAddressBytes,
+    defaultAddress,
+    defaultAddressBytes,
+    defaultAddressBytes,
+    defaultAddressBytes,
+    defaultBigInt,
+    defaultBigInt,
+    defaultBigInt,
+    defaultBigInt,
+    defaultBigInt,
+    defaultBigInt,
+    defaultBigInt,
+    defaultBigInt
+  );
+}
+
+function nextBlock(parent: ethereum.Block): ethereum.Block {
+  const blockNumber = parent.number.plus(BigInt.fromU32(1));
+  const gasUsed = defaultBigInt;
+  const gasLimit = defaultBigInt;
+  const timestamp = parent.timestamp.plus(BigInt.fromU32(1000));
+
+  return new ethereum.Block(
+    defaultAddressBytes,
+    parent.hash,
+    parent.hash,
+    defaultAddress,
+    defaultAddressBytes,
+    defaultAddressBytes,
+    defaultAddressBytes,
+    blockNumber,
+    gasUsed,
+    gasLimit,
+    timestamp,
+    defaultBigInt,
+    defaultBigInt,
+    defaultBigInt,
+    defaultBigInt
+  );
+}
+
+class CurrentBlock {
+  public parent: ethereum.Block = firstBlock();
+  constructor(public current: ethereum.Block = firstBlock()) {}
+  next(): void {
+    this.parent = this.current;
+    this.current = nextBlock(this.current);
+  }
+  reset(): void {
+    this.current = firstBlock();
+  }
+}
+
+export const mockBlock = new CurrentBlock();

--- a/subgraph/tests/subscriptions-utils.ts
+++ b/subgraph/tests/subscriptions-utils.ts
@@ -54,9 +54,13 @@ export function createSubscribeEvent(
 
 export function createUnsubscribeEvent(
   user: Address,
-  epoch: BigInt
+  epoch: BigInt,
+  logIndex: u32 = 2
 ): Unsubscribe {
   let unsubscribeEvent = changetype<Unsubscribe>(mockEvent());
+  if (logIndex != null) {
+    unsubscribeEvent.logIndex = BigInt.fromU32(logIndex);
+  }
 
   unsubscribeEvent.parameters.push(
     new ethereum.EventParam('user', ethereum.Value.fromAddress(user))

--- a/subgraph/tests/subscriptions-utils.ts
+++ b/subgraph/tests/subscriptions-utils.ts
@@ -1,4 +1,5 @@
 import {newMockEvent} from 'matchstick-as';
+
 import {ethereum, Address, BigInt} from '@graphprotocol/graph-ts';
 import {
   AuthorizedSignerAdded,
@@ -6,15 +7,26 @@ import {
   Subscribe,
   Unsubscribe,
 } from '../generated/Subscriptions/Subscriptions';
+import {mockBlock} from './block-utils';
+
+function mockEvent(): ethereum.Event {
+  const event = newMockEvent();
+  event.block = mockBlock.current;
+  return event;
+}
 
 export function createSubscribeEvent(
   user: Address,
   epoch: BigInt,
   start: BigInt,
   end: BigInt,
-  pricePerBlock: BigInt
+  pricePerBlock: BigInt,
+  logIndex: u32 = 0
 ): Subscribe {
-  let subscribeEvent = changetype<Subscribe>(newMockEvent());
+  let subscribeEvent = changetype<Subscribe>(mockEvent());
+  if (logIndex != null) {
+    subscribeEvent.logIndex = BigInt.fromU32(logIndex);
+  }
 
   subscribeEvent.parameters = new Array();
 
@@ -44,9 +56,7 @@ export function createUnsubscribeEvent(
   user: Address,
   epoch: BigInt
 ): Unsubscribe {
-  let unsubscribeEvent = changetype<Unsubscribe>(newMockEvent());
-
-  unsubscribeEvent.parameters = new Array();
+  let unsubscribeEvent = changetype<Unsubscribe>(mockEvent());
 
   unsubscribeEvent.parameters.push(
     new ethereum.EventParam('user', ethereum.Value.fromAddress(user))
@@ -63,7 +73,7 @@ export function createAuthorizedSignerAddedEvent(
   authorizedSigner: Address
 ): AuthorizedSignerAdded {
   let authorizedSignerAddedEvent = changetype<AuthorizedSignerAdded>(
-    newMockEvent()
+    mockEvent()
   );
 
   authorizedSignerAddedEvent.parameters = new Array();
@@ -89,7 +99,7 @@ export function createAuthorizedSignerRemovedEvent(
   authorizedSigner: Address
 ): AuthorizedSignerRemoved {
   let authorizedSignerRemovedEvent = changetype<AuthorizedSignerRemoved>(
-    newMockEvent()
+    mockEvent()
   );
 
   authorizedSignerRemovedEvent.parameters = new Array();

--- a/subgraph/tests/subscriptions.test.ts
+++ b/subgraph/tests/subscriptions.test.ts
@@ -9,7 +9,7 @@ import {
 
 import {Address, BigInt, Bytes} from '@graphprotocol/graph-ts';
 
-import {Subscription} from '../generated/schema';
+import {UserSubscription} from '../generated/schema';
 
 import {
   USER_SUBSCRIPTION_EVENT_TYPE__CANCELED,
@@ -117,7 +117,7 @@ describe('Describe entity assertions', () => {
 
   test('handle Unsubscribe', () => {
     // build Subscription that is being removed (this is the ActiveSub that gets build in the beforeAll hook)
-    let sub = new Subscription(Address.fromString(user));
+    let sub = new UserSubscription(Address.fromString(user));
     sub.start = BigInt.fromU32(2000);
     sub.end = BigInt.fromU32(5000);
     sub.rate = BigInt.fromU32(10)
@@ -421,10 +421,20 @@ function assertSubscription(
   expectedRate: BigInt,
   cancelled: boolean = false
 ): void {
-  assert.entityCount('Subscription', 1);
-  assert.fieldEquals('Subscription', user, 'user', user);
-  assert.fieldEquals('Subscription', user, 'start', expectedStart.toString());
-  assert.fieldEquals('Subscription', user, 'end', expectedEnd.toString());
-  assert.fieldEquals('Subscription', user, 'rate', expectedRate.toString());
-  assert.fieldEquals('Subscription', user, 'cancelled', cancelled.toString());
+  assert.entityCount('UserSubscription', 1);
+  assert.fieldEquals('UserSubscription', user, 'user', user);
+  assert.fieldEquals(
+    'UserSubscription',
+    user,
+    'start',
+    expectedStart.toString()
+  );
+  assert.fieldEquals('UserSubscription', user, 'end', expectedEnd.toString());
+  assert.fieldEquals('UserSubscription', user, 'rate', expectedRate.toString());
+  assert.fieldEquals(
+    'UserSubscription',
+    user,
+    'cancelled',
+    cancelled.toString()
+  );
 }

--- a/subgraph/tests/subscriptions.test.ts
+++ b/subgraph/tests/subscriptions.test.ts
@@ -134,7 +134,7 @@ describe('Describe entity assertions', () => {
     assert.entityCount('Unsubscribe', 1);
     assert.entityCount('UserSubscriptionCanceledEvent', 1);
 
-    assert.fieldEquals('Subscription', user, 'end', '0');
+    assertSubscription(user, sub.start, sub.end, sub.rate, true);
 
     const canceledEventId = buildUserSubscriptionEventId(
       Bytes.fromHexString(user),
@@ -147,6 +147,7 @@ describe('Describe entity assertions', () => {
       'eventType',
       USER_SUBSCRIPTION_EVENT_TYPE__CANCELED
     );
+
     let tokensReturned = calculateUnlockedTokens(sub, event);
     assert.fieldEquals(
       'UserSubscriptionCanceledEvent',
@@ -272,7 +273,7 @@ describe('Describe entity assertions', () => {
     );
 
     assert.entityCount('Subscribe', 2);
-    assert.entityCount('Unsubscribe', 0);
+    assert.entityCount('Unsubscribe', 1);
 
     assertSubscription(user, start, end, rate);
 
@@ -417,11 +418,13 @@ function assertSubscription(
   user: string,
   expectedStart: BigInt,
   expectedEnd: BigInt,
-  expectedRate: BigInt
+  expectedRate: BigInt,
+  cancelled: boolean = false
 ): void {
   assert.entityCount('Subscription', 1);
   assert.fieldEquals('Subscription', user, 'user', user);
   assert.fieldEquals('Subscription', user, 'start', expectedStart.toString());
   assert.fieldEquals('Subscription', user, 'end', expectedEnd.toString());
   assert.fieldEquals('Subscription', user, 'rate', expectedRate.toString());
+  assert.fieldEquals('Subscription', user, 'cancelled', cancelled.toString());
 }

--- a/subgraph/tests/subscriptions.test.ts
+++ b/subgraph/tests/subscriptions.test.ts
@@ -9,7 +9,7 @@ import {
 
 import {Address, BigInt, Bytes} from '@graphprotocol/graph-ts';
 
-import {ActiveSubscription} from '../generated/schema';
+import {Subscription} from '../generated/schema';
 
 import {
   USER_SUBSCRIPTION_EVENT_TYPE__CANCELED,
@@ -77,16 +77,11 @@ describe('Describe entity assertions', () => {
     assert.entityCount('User', 1);
     assert.fieldEquals('User', user, 'eventCount', '1'); // 1 UserSubscriptionCreatedEvent
 
-    assert.entityCount('ActiveSubscription', 1);
-    assert.fieldEquals('ActiveSubscription', user, 'user', user);
-    assert.fieldEquals('ActiveSubscription', user, 'start', '2000');
-    assert.fieldEquals('ActiveSubscription', user, 'end', '5000');
-    assert.fieldEquals(
-      'ActiveSubscription',
-      user,
-      'rate',
-      '2000000000000000000'
-    );
+    assert.entityCount('Subscription', 1);
+    assert.fieldEquals('Subscription', user, 'user', user);
+    assert.fieldEquals('Subscription', user, 'start', '2000');
+    assert.fieldEquals('Subscription', user, 'end', '5000');
+    assert.fieldEquals('Subscription', user, 'rate', '2000000000000000000');
 
     // validate UserSubscriptionCreatedEvent record created
     assert.entityCount('UserSubscriptionCreatedEvent', 1);
@@ -122,8 +117,8 @@ describe('Describe entity assertions', () => {
   });
 
   test('handle Unsubscribe', () => {
-    // build ActiveSubscription that is being removed (this is the ActiveSub that gets build in the beforeAll hook)
-    let sub = new ActiveSubscription(Address.fromString(user));
+    // build Subscription that is being removed (this is the ActiveSub that gets build in the beforeAll hook)
+    let sub = new Subscription(Address.fromString(user));
     sub.start = BigInt.fromU32(2000);
     sub.end = BigInt.fromU32(5000);
     sub.rate = BigInt.fromU32(10)
@@ -140,7 +135,7 @@ describe('Describe entity assertions', () => {
     assert.entityCount('Unsubscribe', 1);
     assert.entityCount('UserSubscriptionCanceledEvent', 1);
 
-    assert.fieldEquals('ActiveSubscription', user, 'end', '0');
+    assert.fieldEquals('Subscription', user, 'end', '0');
 
     const canceledEventId = buildUserSubscriptionEventId(
       Bytes.fromHexString(user),
@@ -184,12 +179,12 @@ describe('Describe entity assertions', () => {
     assert.entityCount('Subscribe', 2);
     assert.entityCount('Unsubscribe', 0);
 
-    assert.entityCount('ActiveSubscription', 1);
-    assert.fieldEquals('ActiveSubscription', user, 'user', user);
-    assert.fieldEquals('ActiveSubscription', user, 'start', start.toString());
-    assert.fieldEquals('ActiveSubscription', user, 'end', end.toString());
+    assert.entityCount('Subscription', 1);
+    assert.fieldEquals('Subscription', user, 'user', user);
+    assert.fieldEquals('Subscription', user, 'start', start.toString());
+    assert.fieldEquals('Subscription', user, 'end', end.toString());
 
-    assert.fieldEquals('ActiveSubscription', user, 'rate', rate.toString());
+    assert.fieldEquals('Subscription', user, 'rate', rate.toString());
     // validate only 1 UserSubscriptionCreatedEvent record created
     assert.entityCount('UserSubscriptionCreatedEvent', 1);
     // // validate that a UserSubscriptionRenewalEvent is created as the subscription was extended
@@ -218,11 +213,11 @@ describe('Describe entity assertions', () => {
     assert.entityCount('Subscribe', 2);
     assert.entityCount('Unsubscribe', 0);
 
-    assert.entityCount('ActiveSubscription', 1);
-    assert.fieldEquals('ActiveSubscription', user, 'user', user);
-    assert.fieldEquals('ActiveSubscription', user, 'start', start.toString());
-    assert.fieldEquals('ActiveSubscription', user, 'end', end.toString());
-    assert.fieldEquals('ActiveSubscription', user, 'rate', rate.toString());
+    assert.entityCount('Subscription', 1);
+    assert.fieldEquals('Subscription', user, 'user', user);
+    assert.fieldEquals('Subscription', user, 'start', start.toString());
+    assert.fieldEquals('Subscription', user, 'end', end.toString());
+    assert.fieldEquals('Subscription', user, 'rate', rate.toString());
     // validate only 1 UserSubscriptionCreatedEvent record created
     assert.entityCount('UserSubscriptionCreatedEvent', 1);
     // validate that a UserSubscriptionUpgradeEvent is created as the subscription was rate was increased
@@ -274,11 +269,11 @@ describe('Describe entity assertions', () => {
     assert.entityCount('Subscribe', 2);
     assert.entityCount('Unsubscribe', 0);
 
-    assert.entityCount('ActiveSubscription', 1);
-    assert.fieldEquals('ActiveSubscription', user, 'user', user);
-    assert.fieldEquals('ActiveSubscription', user, 'start', start.toString());
-    assert.fieldEquals('ActiveSubscription', user, 'end', end.toString());
-    assert.fieldEquals('ActiveSubscription', user, 'rate', rate.toString());
+    assert.entityCount('Subscription', 1);
+    assert.fieldEquals('Subscription', user, 'user', user);
+    assert.fieldEquals('Subscription', user, 'start', start.toString());
+    assert.fieldEquals('Subscription', user, 'end', end.toString());
+    assert.fieldEquals('Subscription', user, 'rate', rate.toString());
 
     // validate only 1 UserSubscriptionCreatedEvent record created
     assert.entityCount('UserSubscriptionCreatedEvent', 1);
@@ -312,7 +307,7 @@ describe('Describe entity assertions', () => {
     assert.fieldEquals('User', user, 'eventCount', '2'); // 1 UserSubscriptionCreatedEvent, 1 UserSubscriptionDowngradeEvent
   });
 
-  test('should be able to add an AuthorizedSigner entity for the ActiveSubscription. but must be unique', () => {
+  test('should be able to add an AuthorizedSigner entity for the Subscription. but must be unique', () => {
     const signer = '0x0000000000000000000000000000000000000002';
     let subscriptionOwner = Address.fromString(user);
     let authorizedSigner = Address.fromString(signer);

--- a/subgraph/tests/tsconfig.json
+++ b/subgraph/tests/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  // This file is needed for the IDE to find the AssemblyScript types for tests
+  "extends": "../tsconfig.json",
+  "include": ["."]
+}


### PR DESCRIPTION
Howdy. This PR does mainly two things:

- Updates test cases for _Renew_, _Upgrade_ and _Downgrade_ to handle a pair of events `(Unsubscribe > Subscribe)` in one block.
- Changes _Subscribe_, and _Unsubscribe_ handler to correctly derive the events based on user intent, and preserve Subscription through this whole time.
  - To say if a Subscription is _active_, we need to check if `.cancelled == false` and `.end < now`.

<img width="541" alt="image" src="https://user-images.githubusercontent.com/15332326/227365360-d94e5bc7-e547-43c3-b46f-ddeb14854d01.png">
