### PR TITLE
Set `currentSubscription{X}` fields based on `event.params`

### DIFF
--- a/subgraph/src/subscriptions.ts
+++ b/subgraph/src/subscriptions.ts
@@ -259,12 +259,14 @@ function buildAndSaveUserSubscriptionUpgradeEvent(
   upgradeEvent.blockTimestamp = event.block.timestamp;
   upgradeEvent.txHash = event.transaction.hash;
   upgradeEvent.eventType = USER_SUBSCRIPTION_EVENT_TYPE__UPGRADE;
-  upgradeEvent.currentSubscriptionStart = sub.start;
-  upgradeEvent.currentSubscriptionEnd = sub.end;
-  upgradeEvent.currentSubscriptionRate = sub.rate;
+
   upgradeEvent.previousSubscriptionStart = sub.start;
   upgradeEvent.previousSubscriptionEnd = sub.end;
   upgradeEvent.previousSubscriptionRate = sub.rate;
+
+  upgradeEvent.currentSubscriptionStart = event.params.start;
+  upgradeEvent.currentSubscriptionEnd = event.params.end;
+  upgradeEvent.currentSubscriptionRate = event.params.rate;
   upgradeEvent.save();
 
   incrementUserEventCount(user);
@@ -286,12 +288,15 @@ function buildAndSaveUserSubscriptionDowngradeEvent(
   downgradeEvent.blockTimestamp = event.block.timestamp;
   downgradeEvent.txHash = event.transaction.hash;
   downgradeEvent.eventType = USER_SUBSCRIPTION_EVENT_TYPE__DOWNGRADE;
-  downgradeEvent.currentSubscriptionStart = sub.start;
-  downgradeEvent.currentSubscriptionEnd = sub.end;
-  downgradeEvent.currentSubscriptionRate = sub.rate;
+
   downgradeEvent.previousSubscriptionStart = sub.start;
   downgradeEvent.previousSubscriptionEnd = sub.end;
   downgradeEvent.previousSubscriptionRate = sub.rate;
+
+  downgradeEvent.currentSubscriptionStart = event.params.start;
+  downgradeEvent.currentSubscriptionEnd = event.params.end;
+  downgradeEvent.currentSubscriptionRate = event.params.rate;
+
   downgradeEvent.save();
 
   incrementUserEventCount(user);

--- a/subgraph/tests/subscriptions.test.ts
+++ b/subgraph/tests/subscriptions.test.ts
@@ -36,6 +36,7 @@ import {
   createUnsubscribeEvent,
 } from './subscriptions-utils';
 import {mockBlock} from './block-utils';
+import {assertFields} from './test-utils';
 
 // Tests structure (matchstick-as >=0.5.0)
 // https://thegraph.com/docs/en/developer/matchstick/#tests-structure-0-5-0
@@ -230,7 +231,7 @@ describe('Describe entity assertions', () => {
       mockBlock.current.timestamp
     );
 
-    const expectedFields = [
+    assertFields('UserSubscriptionUpgradeEvent', upgradeEventId.toHex(), [
       'previousSubscriptionStart',
       INITIAL_START.toString(),
       'previousSubscriptionEnd',
@@ -243,16 +244,7 @@ describe('Describe entity assertions', () => {
       end.toString(),
       'currentSubscriptionRate',
       rate.toString(),
-    ];
-
-    for (let i = 0; i < expectedFields.length; i += 2) {
-      assert.fieldEquals(
-        'UserSubscriptionUpgradeEvent',
-        upgradeEventId.toHex(),
-        expectedFields[i],
-        expectedFields[i + 1]
-      );
-    }
+    ]);
 
     assert.fieldEquals('User', user, 'eventCount', '2');
   });
@@ -294,24 +286,21 @@ describe('Describe entity assertions', () => {
       mockBlock.current.timestamp
     );
 
-    assert.fieldEquals(
-      'UserSubscriptionDowngradeEvent',
-      downgradeEventId.toHex(),
+    assertFields('UserSubscriptionDowngradeEvent', downgradeEventId.toHex(), [
       'previousSubscriptionStart',
-      INITIAL_START.toString() // value from `upgrade Subscription` test above before this event is received
-    );
-    assert.fieldEquals(
-      'UserSubscriptionDowngradeEvent',
-      downgradeEventId.toHex(),
+      INITIAL_START.toString(),
       'previousSubscriptionEnd',
-      INITIAL_END.toString() // value from `upgrade Subscription` test above before this event is received
-    );
-    assert.fieldEquals(
-      'UserSubscriptionDowngradeEvent',
-      downgradeEventId.toHex(),
+      INITIAL_END.toString(),
       'previousSubscriptionRate',
-      INITIAL_RATE.toString() // value from `upgrade Subscription` test above before this event is received
-    );
+      INITIAL_RATE.toString(),
+      'currentSubscriptionStart',
+      start.toString(),
+      'currentSubscriptionEnd',
+      end.toString(),
+      'currentSubscriptionRate',
+      rate.toString(),
+    ]);
+
     assert.fieldEquals('User', user, 'eventCount', '2'); // 1 UserSubscriptionCreatedEvent, 1 UserSubscriptionDowngradeEvent
   });
 

--- a/subgraph/tests/subscriptions.test.ts
+++ b/subgraph/tests/subscriptions.test.ts
@@ -229,24 +229,30 @@ describe('Describe entity assertions', () => {
       USER_SUBSCRIPTION_EVENT_TYPE__UPGRADE,
       mockBlock.current.timestamp
     );
-    assert.fieldEquals(
-      'UserSubscriptionUpgradeEvent',
-      upgradeEventId.toHex(),
+
+    const expectedFields = [
       'previousSubscriptionStart',
-      INITIAL_START.toString() // value from `update Subscription` test above before this event is received
-    );
-    assert.fieldEquals(
-      'UserSubscriptionUpgradeEvent',
-      upgradeEventId.toHex(),
+      INITIAL_START.toString(),
       'previousSubscriptionEnd',
-      INITIAL_END.toString() // value from `update Subscription` test above before this event is received
-    );
-    assert.fieldEquals(
-      'UserSubscriptionUpgradeEvent',
-      upgradeEventId.toHex(),
+      INITIAL_END.toString(),
       'previousSubscriptionRate',
-      INITIAL_RATE.toString() // value from `update Subscription` test above before this event is received
-    );
+      INITIAL_RATE.toString(),
+      'currentSubscriptionStart',
+      start.toString(),
+      'currentSubscriptionEnd',
+      end.toString(),
+      'currentSubscriptionRate',
+      rate.toString(),
+    ];
+
+    for (let i = 0; i < expectedFields.length; i += 2) {
+      assert.fieldEquals(
+        'UserSubscriptionUpgradeEvent',
+        upgradeEventId.toHex(),
+        expectedFields[i],
+        expectedFields[i + 1]
+      );
+    }
 
     assert.fieldEquals('User', user, 'eventCount', '2');
   });

--- a/subgraph/tests/test-utils.ts
+++ b/subgraph/tests/test-utils.ts
@@ -1,0 +1,11 @@
+import {assert} from 'matchstick-as';
+
+export function assertFields(
+  name: string,
+  id: string,
+  expectedFields: Array<string>
+): void {
+  for (let i = 0; i < expectedFields.length; i += 2) {
+    assert.fieldEquals(name, id, expectedFields[i], expectedFields[i + 1]);
+  }
+}


### PR DESCRIPTION
Fixes the following issue:

<img width="1333" alt="image" src="https://user-images.githubusercontent.com/15332326/227564951-ba67c2d0-80df-4acb-8028-89ba1faf4405.png">
