### PR TITLE
feat(subscription tiers): add subscription tier holder structs

### DIFF
--- a/graph-subscriptions-rs/src/lib.rs
+++ b/graph-subscriptions-rs/src/lib.rs
@@ -13,6 +13,8 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none, Bytes, FromInto};
 use std::io::{self, Write as _};
 
+pub mod subscription_tier;
+
 abigen!(
     Subscriptions,
     "../contract/build/Subscriptions.abi",

--- a/graph-subscriptions-rs/src/subscription_tier.rs
+++ b/graph-subscriptions-rs/src/subscription_tier.rs
@@ -1,0 +1,29 @@
+use serde::Deserialize;
+use serde_with::{serde_as, DisplayFromStr};
+
+#[derive(Debug, Default)]
+pub struct SubscriptionTiers(Vec<SubscriptionTier>);
+
+#[serde_as]
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct SubscriptionTier {
+    /// Payment rate from the subcription contract.
+    #[serde_as(as = "DisplayFromStr")]
+    pub payment_rate: u128,
+    /// Maximum query rate allowed, in queries per second.
+    pub query_rate_limit: u32,
+}
+
+impl SubscriptionTiers {
+    pub fn create(mut tiers: Vec<SubscriptionTier>) -> &'static Self {
+        tiers.sort_by_key(|t| t.payment_rate);
+        Box::leak(Box::new(Self(tiers)))
+    }
+    pub fn tier_for_rate(&self, sub_rate: u128) -> SubscriptionTier {
+        self.0
+            .iter()
+            .find(|tier| tier.payment_rate <= sub_rate)
+            .cloned()
+            .unwrap_or_default()
+    }
+}


### PR DESCRIPTION
# Description

After a discussion with @Theodus, add the `SubscriptionTier` struct holders to the `graph-subscription-rs` lib for use in both the subscriptions api and gateway