### PR TITLE
subgraph | add arbitrum-one addr/start block for deployment

### DIFF
--- a/subgraph/networks.json
+++ b/subgraph/networks.json
@@ -9,5 +9,11 @@
       "address": "0x29f49a438c747e7Dd1bfe7926b03783E47f9447B",
       "startBlock": 10350834
     }
+  },
+  "arbitrum-one": {
+    "Subscriptions": {
+      "address": "0x6e4584820Da058850ed523008F6f0e3aebCE16F5",
+      "startBlock": 79799011
+    }
   }
 }


### PR DESCRIPTION
# Description

Add config to `subgraph/networks.json` for the arbitrum-one subscriptions contract. Deployed subgraph to arbitrum-one