### PR TITLE
feat(ticket payload): add PartialEq, Eq derive traits to TicketPayload

### DIFF
--- a/graph-subscriptions-rs/src/lib.rs
+++ b/graph-subscriptions-rs/src/lib.rs
@@ -38,7 +38,7 @@ impl From<Address> for AddressBytes { fn from(value: Address) -> Self { Self(val
 
 #[serde_as]
 #[skip_serializing_none]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct TicketPayload {
     /// Address associated with the secret key used to sign the ticket.
     #[serde_as(as = "FromInto<AddressBytes>")]


### PR DESCRIPTION
# Description

Using the `TicketPayload` in the subscriptions api when parsing the ticket from the message sent by the kafka topic. Utilize `PartialEq, Eq` in the parent types to this for comparisons.