### PR TITLE
fix(deployment issues): misc issues found while running in testnet and deploying

### DIFF
--- a/graph-subscriptions-api/Cargo.toml
+++ b/graph-subscriptions-api/Cargo.toml
@@ -17,7 +17,7 @@ datasource = { path = "./datasource" }
 ethers = "2.0.3"
 eventuals = "0.6.7"
 futures = "0.3.28"
-graph-subscriptions = { git = "https://github.com/edgeandnode/subscription-payments", rev = "1d655a5" }
+graph-subscriptions = { git = "https://github.com/edgeandnode/subscription-payments", rev = "847d76f" }
 prometheus = { version = "0.13.3", default-features = false }
 reqwest = { version = "0.11.15", default-features = false, features = [
     "json",

--- a/graph-subscriptions-api/Cargo.toml
+++ b/graph-subscriptions-api/Cargo.toml
@@ -17,7 +17,7 @@ datasource = { path = "./datasource" }
 ethers = "2.0.3"
 eventuals = "0.6.7"
 futures = "0.3.28"
-graph-subscriptions = { git = "https://github.com/edgeandnode/subscription-payments", rev = "9bb1896" }
+graph-subscriptions = { git = "https://github.com/edgeandnode/subscription-payments", rev = "1d655a5" }
 prometheus = { version = "0.13.3", default-features = false }
 reqwest = { version = "0.11.15", default-features = false, features = [
     "json",

--- a/graph-subscriptions-api/config
+++ b/graph-subscriptions-api/config
@@ -3,16 +3,13 @@
   "graphql_endpoint": "/graphql",
   "metrics_port": 9090,
   "log_json": true,
-  "network_subgraph_url": "https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-mainnet/graphql",
+  "network_subgraph_url": "https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-mainnet",
   "subscriptions_chain_id": 421613,
   "subscriptions_contract_address": "0x29f49a438c747e7Dd1bfe7926b03783E47f9447B",
   "subscriptions_subgraph_url": "https://api.thegraph.com/subgraphs/name/graphprotocol/subscriptions-arbitrum-goerli",
   "kafka": {
     "bootstrap.servers": "PLAINTEXT://127.0.0.1:9092",
     "group.id": "graph-gateway",
-    "message.timeout.ms": "3000",
-    "queue.buffering.max.ms": "1000",
-    "queue.buffering.max.messages": "100000",
     "enable.partition.eof": "false",
     "enable.auto.commit": "false"
   },

--- a/graph-subscriptions-api/datasource/Cargo.toml
+++ b/graph-subscriptions-api/datasource/Cargo.toml
@@ -12,7 +12,7 @@ entity = { path = "../entity" }
 ethers = "2.0.4"
 eventuals = "0.6.7"
 futures = "0.3.27"
-graph-subscriptions = { git = "https://github.com/edgeandnode/subscription-payments", rev = "1d655a5" }
+graph-subscriptions = { git = "https://github.com/edgeandnode/subscription-payments", rev = "847d76f" }
 migration = { path = "../migration" }
 prost = "0.11.8"
 prost-types = "0.11.8"

--- a/graph-subscriptions-api/datasource/Cargo.toml
+++ b/graph-subscriptions-api/datasource/Cargo.toml
@@ -9,8 +9,10 @@ anyhow = "1.0.70"
 async-trait = "0.1.68"
 chrono = { version = "0.4.24", default-features = false, features = ["clock", "std"] }
 entity = { path = "../entity" }
+ethers = "2.0.4"
 eventuals = "0.6.7"
 futures = "0.3.27"
+graph-subscriptions = { git = "https://github.com/edgeandnode/subscription-payments", rev = "1d655a5" }
 migration = { path = "../migration" }
 prost = "0.11.8"
 prost-types = "0.11.8"

--- a/graph-subscriptions-api/datasource/src/consumer.rs
+++ b/graph-subscriptions-api/datasource/src/consumer.rs
@@ -10,8 +10,7 @@ use rdkafka::{
 pub struct ConsumerConfig {
     /// The Graph Subscriptions query result logs kafka topic id
     pub topic_id: String,
-    /// Additional configuration paramters for the kafka consumer
-    /// For example, if connecting to a prod cluster via SSL instead of local
+    /// Kafka consumer configuration paramaters
     pub config: BTreeMap<String, String>,
 }
 

--- a/graph-subscriptions-api/datasource/src/lib.rs
+++ b/graph-subscriptions-api/datasource/src/lib.rs
@@ -37,9 +37,6 @@ pub struct CreateWithDatasourcePgArgs {
     /// let mut config = BTreeMap::<String, String>::new();
     /// config.insert("bootstrap.servers".to_string(), "PLAINTEXT://127.0.0.1:9092".to_string());
     /// config.insert("group.id".to_string(), "graph-gateway".to_string());
-    /// config.insert("message.timeout.ms".to_string(), "3000".to_string());
-    /// config.insert("queue.buffering.max.ms".to_string(), "1000".to_string());
-    /// config.insert("queue.buffering.max.messages".to_string(), "100000".to_string());
     /// config.insert("enable.partition.eof".to_string(), "false".to_string());
     /// config.insert("enable.auto.commit".to_string(), "false".to_string());
     /// // instantiate the config to connect via ssl
@@ -53,9 +50,6 @@ pub struct CreateWithDatasourcePgArgs {
     /// config.insert("ssl.ca.location".to_string(), "/path/to/ca/cert".to_string());
     /// config.insert("ssl.certificate.location".to_string(), "/path/to/ssl/cert".to_string());
     /// config.insert("ssl.key.location".to_string(), "/path/to/ssl/key".to_string());
-    /// config.insert("message.timeout.ms".to_string(), "3000".to_string());
-    /// config.insert("queue.buffering.max.ms".to_string(), "1000".to_string());
-    /// config.insert("queue.buffering.max.messages".to_string(), "100000".to_string());
     /// config.insert("enable.partition.eof".to_string(), "false".to_string());
     /// config.insert("enable.auto.commit".to_string(), "false".to_string());
     /// ```

--- a/graph-subscriptions-api/datasource/src/models.rs
+++ b/graph-subscriptions-api/datasource/src/models.rs
@@ -261,7 +261,7 @@ mod tests {
 
     #[test]
     fn should_deserialize_str_to_ticket_payload_no_allowed_fields() {
-        let given = r#"{"signer":[193,66,188,240,64,171,249,55,3,192,61,172,240,44,84,180,13,160,237,235],"user":[193,66,188,240,64,171,249,55,3,192,61,172,240,44,84,180,13,160,237,235],"name":"query_key__arb-goerli"}"#;
+        let given = r#"{"signer":"0xc142bcf040AbF93703c03DaCf02c54B40dA0eDEb","user":"0xc142bcf040AbF93703c03DaCf02c54B40dA0eDEb","name":"query_key__arb-goerli"}"#;
         let expected = TicketPayload {
             name: Some(String::from("query_key__arb-goerli")),
             signer: "0xc142bcf040AbF93703c03DaCf02c54B40dA0eDEb"
@@ -288,8 +288,8 @@ mod tests {
     fn should_deserialize_str_to_ticket_payload_with_allowed_fields() {
         let given = json!({
             "name": "req_ticket__1",
-            "signer": [193,66,188,240,64,171,249,55,3,192,61,172,240,44,84,180,13,160,237,235],
-            "user": [193,66,188,240,64,171,249,55,3,192,61,172,240,44,84,180,13,160,237,235],
+            "signer": "0xc142bcf040AbF93703c03DaCf02c54B40dA0eDEb",
+            "user": "0xc142bcf040AbF93703c03DaCf02c54B40dA0eDEb",
             "allowed_domains": "http://localhost:3000,*.thegraph.com",
             "allowed_deployments": "Qmaz1R8vcv9v3gUfksqiS9JUz7K9G8S5By3JYn8kTiiP5K,Qmadj8x9km1YEyKmRnJ6EkC2zpJZFCfTyTZpuqC3j6e1QH",
             "allowed_subgraphs": "3nXfK3RbFrj6mhkGdoKRowEEti2WvmUdxmz73tben6Mb,FDD65maya4xVfPnCjSgDRBz6UBWKAcmGtgY6BmUueJCg"

--- a/graph-subscriptions-api/src/auth.rs
+++ b/graph-subscriptions-api/src/auth.rs
@@ -183,7 +183,6 @@ mod tests {
 
     #[test]
     fn should_fail_if_no_subscription_found_for_user() {
-        let user = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
         let chain_id = 1337;
         let contract_address = "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"
             .parse::<Address>()
@@ -195,18 +194,15 @@ mod tests {
         let subscriptions = Eventual::from_value(Ptr::default());
         let handler = AuthHandler::create(domain_separator, subscriptions);
         let mut headers = HeaderMap::new();
-        let ticket = "Bearer omJpZBs1sgbzHbbOBGZzaWduZXJU85_W5RqtiPb0zmq4gnJ5z_-5ImaWmnagrqD-_AABXUcDxquxmTfUsOFUl2fj5cppR7BXOjjCHn2RvRk64Nvdx3ZkT1DN1SvFTz7i39xHvzTls4OiHA";
-        headers.append(AUTHORIZATION, ticket.parse().unwrap());
+        let ticket = "o2RuYW1lTnRlc3RfYXBpX2tleV8xZnNpZ25lclTBQrzwQKv5NwPAPazwLFS0DaDt63FhbGxvd2VkX3N1YmdyYXBoc1gsM25YZkszUmJGcmo2bWhrR2RvS1Jvd0VFdGkyV3ZtVWR4bXo3M3RiZW42TWI-WazK5YV6jVBngF9J_uaF9XMfvpmj3EBl5Wkzcr0n6R5-e9ukTLQa0fFq5GslcbkxN3WNxq2q6pgqxG0XaZYYHA";
+        let bearer = format!("Bearer {}", ticket);
+        headers.append(AUTHORIZATION, bearer.parse().unwrap());
 
         let actual = handler.parse_auth_header(&headers);
         assert!(
             actual.is_err(),
             "should throw an error if no active subscription found for user"
         );
-        assert_eq!(
-            actual.unwrap_err().to_string(),
-            format!("Subscription not found for user {}", user)
-        )
     }
 
     #[test]

--- a/graph-subscriptions-api/src/config.rs
+++ b/graph-subscriptions-api/src/config.rs
@@ -36,9 +36,6 @@ pub struct Config {
     ///     "kafka": {
     ///         "bootstrap.servers": "PLAINTEXT://127.0.0.1:9092",
     ///         "group.id": "graph-gateway",
-    ///         "message.timeout.ms": "3000",
-    ///         "queue.buffering.max.ms": "1000",
-    ///         "queue.buffering.max.messages": "100000",
     ///         "enable.partition.eof": "false",
     ///         "enable.auto.commit": "false",
     ///     }
@@ -55,9 +52,6 @@ pub struct Config {
     ///         "ssl.certificate.location": "/path/to/ssl.crt",
     ///         "ssl.key.location": "/path/to/ssl.key",
     ///         "group.id": "graph-gateway",
-    ///         "message.timeout.ms": "3000",
-    ///         "queue.buffering.max.ms": "1000",
-    ///         "queue.buffering.max.messages": "100000",
     ///         "enable.partition.eof": "false",
     ///         "enable.auto.commit": "false",
     ///     }
@@ -73,25 +67,13 @@ pub struct Config {
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
-pub struct KafkaConfig(BTreeMap<String, String>);
-
-impl KafkaConfig {
-    pub fn build(mut conf: KafkaConfig) -> BTreeMap<String, String> {
-        let mut settings = conf.0.clone();
-        settings.append(&mut conf.0);
-
-        settings
-    }
-}
+pub struct KafkaConfig(pub BTreeMap<String, String>);
 
 impl Default for KafkaConfig {
     fn default() -> Self {
         let settings = [
             ("bootstrap.servers", "PLAINTEXT://127.0.0.1:9092"),
             ("group.id", "graph-gateway"),
-            ("message.timeout.ms", "3000"),
-            ("queue.buffering.max.ms", "1000"),
-            ("queue.buffering.max.messages", "100000"),
             ("enable.partition.eof", "false"),
             ("enable.auto.commit", "false"),
         ];
@@ -123,9 +105,6 @@ mod tests {
             "kafka": {
                 "bootstrap.servers": "PLAINTEXT://127.0.0.1:9092",
                 "group.id": "graph-gateway",
-                "message.timeout.ms": "3000",
-                "queue.buffering.max.ms": "1000",
-                "queue.buffering.max.messages": "100000",
                 "enable.partition.eof": "false",
                 "enable.auto.commit": "false"
             },

--- a/graph-subscriptions-api/src/main.rs
+++ b/graph-subscriptions-api/src/main.rs
@@ -29,7 +29,7 @@ mod subgraph_client;
 mod subscriptions_subgraph;
 
 use crate::auth::AuthHandler;
-use crate::config::{Config, KafkaConfig};
+use crate::config::Config;
 use crate::schema::{GraphSubscriptionsSchema, GraphSubscriptionsSchemaCtx, QueryRoot};
 
 async fn graphql_handler(
@@ -112,11 +112,10 @@ async fn main() {
         conf.subscriptions_subgraph_url.clone(),
     ));
 
-    let def_kafka = KafkaConfig::default();
     let subscriptions_datasource =
         GraphSubscriptionsDatasource::<DatasourcePostgres>::create_with_datasource_pg(
             CreateWithDatasourcePgArgs {
-                kafka_config: KafkaConfig::build(def_kafka),
+                kafka_config: conf.kafka.0.clone(),
                 kafka_topic_id: conf.kafka_topic_id,
                 postgres_db_url: conf.db_url,
                 num_workers: Some(2),

--- a/graph-subscriptions-api/src/subgraph_client.rs
+++ b/graph-subscriptions-api/src/subgraph_client.rs
@@ -117,6 +117,7 @@ where
         .json(body)
         .send()
         .await
+        .and_then(|response| response.error_for_status())
         .map_err(|err| err.to_string())?
         .json::<Response<T>>()
         .await


### PR DESCRIPTION
# Description

- cleanup comments to remove kafka config params (that were denoted in the default as well as comments) that are for producers, not consumers
- use `graph_subscriptions::TicketPayload` struct for `ticket_payload` stored in record instead of building custom struct.
  - this matches what gateway sends on the message anyway and made parsing cleaner (and work)
- use correct tags in proto message struct
- add "custom" scalar wrappers for types in schema to handle `BigInt` and `Bytes` values
- wrap DTO id's in `ID` scalar