### PR TITLE
Add .find_next_tier to SubscriptionTiers

### DIFF
--- a/graph-subscriptions-rs/src/subscription_tier.rs
+++ b/graph-subscriptions-rs/src/subscription_tier.rs
@@ -30,6 +30,13 @@ impl SubscriptionTiers {
             .cloned()
             .unwrap_or_default()
     }
+
+    pub fn find_next_tier(&self, sub_rate: u128) -> Option<SubscriptionTier> {
+        self.0
+            .iter()
+            .find(|tier| tier.payment_rate > sub_rate)
+            .cloned()
+    }
 }
 
 impl From<Vec<SubscriptionTier>> for SubscriptionTiers {


### PR DESCRIPTION
Okay, I could technically do `as_ref()` and then find it, but it seems nicer this way.