### PR TITLE
fix(graph-subscriptions-rs): tier_for_rate

### DIFF
--- a/graph-subscriptions-rs/src/subscription_tier.rs
+++ b/graph-subscriptions-rs/src/subscription_tier.rs
@@ -26,6 +26,7 @@ impl SubscriptionTiers {
     pub fn tier_for_rate(&self, sub_rate: u128) -> SubscriptionTier {
         self.0
             .iter()
+            .rev()
             .find(|tier| tier.payment_rate <= sub_rate)
             .cloned()
             .unwrap_or_default()
@@ -41,5 +42,41 @@ impl From<Vec<SubscriptionTier>> for SubscriptionTiers {
 impl AsRef<[SubscriptionTier]> for SubscriptionTiers {
     fn as_ref(&self) -> &[SubscriptionTier] {
         &self.0
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{SubscriptionTier, SubscriptionTiers};
+
+    #[test]
+    fn tier_for_rate() {
+        let tiers = SubscriptionTiers::from(vec![
+            SubscriptionTier {
+                payment_rate: 100,
+                queries_per_minute: 1,
+                monthly_query_limit: None,
+            },
+            SubscriptionTier {
+                payment_rate: 200,
+                queries_per_minute: 2,
+                monthly_query_limit: None,
+            },
+            SubscriptionTier {
+                payment_rate: 300,
+                queries_per_minute: 3,
+                monthly_query_limit: None,
+            },
+        ]);
+
+        assert_eq!(tiers.tier_for_rate(99).queries_per_minute, 0);
+        assert_eq!(tiers.tier_for_rate(100).queries_per_minute, 1);
+        assert_eq!(tiers.tier_for_rate(101).queries_per_minute, 1);
+        assert_eq!(tiers.tier_for_rate(199).queries_per_minute, 1);
+        assert_eq!(tiers.tier_for_rate(200).queries_per_minute, 2);
+        assert_eq!(tiers.tier_for_rate(201).queries_per_minute, 2);
+        assert_eq!(tiers.tier_for_rate(299).queries_per_minute, 2);
+        assert_eq!(tiers.tier_for_rate(300).queries_per_minute, 3);
+        assert_eq!(tiers.tier_for_rate(500).queries_per_minute, 3);
     }
 }


### PR DESCRIPTION
The original search order would often result in selecting a lower tier than expected.